### PR TITLE
Get working on all TS version >= 2.8.0

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -1,0 +1,3 @@
+typescript:
+  versions: ">= 2.8.0"
+  commands: yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ node_js:
 - lts/*
 - node
 
+script:
+  - yarn run test:all-versions
+
 before_deploy:
   - npm run build
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "coverage": "yarn build:coverage && node --harmony ./node_modules/istanbul/lib/cli.js cover --root ./build/src --report lcov --report text ./node_modules/mocha/bin/_mocha ./build/test/**/*.test.js",
     "test": "NODE_ENV=test mocha --opts test/mocha.opts",
     "test:watch": "yarn run test --watch",
+    "test:all-versions": "yarn tav",
     "lint": "yarn lint:tslint",
     "lint:tslint": "tslint -p .",
     "lint:prettier": "prettier \"{src,test}/**/*.{ts,js}\" --list-different",
@@ -65,10 +66,11 @@
     "rollup-plugin-uglify": "2.0.1",
     "sinon": "^4.0.2",
     "sinon-chai": "2.14.0",
+    "test-all-versions": "3.3.3",
     "ts-node": "4.0.1",
     "tslint": "5.9.0",
     "tslint-config-prettier": "1.6.0",
-    "typescript": "2.8.3",
+    "typescript": "3.0.3",
     "winston": "^2.3.1"
   },
   "dependencies": {

--- a/src/attribute.ts
+++ b/src/attribute.ts
@@ -5,7 +5,7 @@ export type Attr<T> = (() => T) | { new (...args: any[]): T & object }
 export type AttrType<T> = Attr<T>
 
 export interface AttrRecord<T> {
-  name?: string | symbol
+  name?: string
   type?: AttrType<T>
   persist?: boolean
 }
@@ -23,14 +23,14 @@ export type AttributeValue<Attributes> = {
 }
 
 export type AttributeOptions = Partial<{
-  name: string | symbol
+  name: string
   type: () => any
   persist: boolean
 }>
 
 export class Attribute<T = any> {
   isRelationship = false
-  name!: string | symbol
+  name!: string
   type?: T = undefined
   persist: boolean = true
   owner!: typeof SpraypaintBase

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -78,7 +78,7 @@ const AttrDecoratorFactory: {
 
   const attrFunction = (
     ModelClass: typeof SpraypaintBase,
-    propKey: string | symbol
+    propKey: string
   ): PropertyDescriptor => {
     ensureModelInheritance(ModelClass)
 
@@ -112,7 +112,7 @@ const AttrDecoratorFactory: {
       attrDefinition = new Attribute(configOrTarget)
     }
 
-    return (target: SpraypaintBase, propKey: string | symbol) => {
+    return (target: SpraypaintBase, propKey: string) => {
       return attrFunction(<any>target.constructor, propKey)
     }
   }

--- a/src/util/omit.ts
+++ b/src/util/omit.ts
@@ -1,4 +1,4 @@
 // export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
 export type Diff<T extends string, U extends string> = ({ [P in T]: P } &
   { [P in U]: never } & { [x: string]: never })[T]
-export type Omit<T, K extends keyof T> = { [P in Diff<keyof T, K>]: T[P] }
+export type Omit<T, K> = { [P in Diff<Extract<keyof T, string>, Extract<keyof K, string>>]: T[P] }

--- a/src/util/write-payload.ts
+++ b/src/util/write-payload.ts
@@ -241,7 +241,7 @@ export class WritePayload<T extends SpraypaintBase> {
     return false
   }
 
-  private _eachAttribute<K extends keyof T>(callback: (key: K, val: T[K]) => void): void {
+  private _eachAttribute<K extends Extract<keyof T, string>>(callback: (key: K, val: T[K]) => void): void {
     const modelAttrs = this.model.typedAttributes
 
     Object.keys(modelAttrs).forEach(key => {

--- a/src/validation-errors.ts
+++ b/src/validation-errors.ts
@@ -46,5 +46,3 @@ export type ErrorAttrs<T extends SpraypaintBase, K extends keyof T> = {
    */
   [key: string] : IValidationError<T> | undefined
 }
-
-let f = new SpraypaintBase()

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -20,19 +20,19 @@ export class Person extends ApplicationRecord {
   static endpoint = "/v1/people"
   static jsonapiType = "people"
 
-  @Attr firstName: string | null
-  @Attr lastName: string | null
+  @Attr firstName!: string | null
+  @Attr lastName!: string | null
 }
 
 @Model()
 export class PersonWithExtraAttr extends Person {
   @Attr({ persist: false })
-  extraThing: string
+  extraThing!: string
 }
 
 @Model({ keyCase: { server: "snake", client: "snake" } })
 export class PersonWithoutCamelizedKeys extends Person {
-  @Attr first_name: string
+  @Attr first_name!: string
 }
 
 @Model({ keyCase: { server: "dash", client: "camel" } })
@@ -43,25 +43,25 @@ export class PersonWithDasherizedKeys extends Person {}
   jsonapiType: "authors"
 })
 export class Author extends Person {
-  @Attr nilly: string
+  @Attr nilly!: string
   @HasMany({ type: "multi_words" })
-  multiWords: MultiWord[]
-  @HasMany("books") specialBooks: Book[]
-  @HasMany() books: Book[]
-  @HasMany() tags: Tag[]
+  multiWords!: MultiWord[]
+  @HasMany("books") specialBooks!: Book[]
+  @HasMany() books!: Book[]
+  @HasMany() tags!: Tag[]
   @BelongsTo({ type: "genres" })
-  genre: Genre
-  @HasOne("bios") bio: Bio
+  genre!: Genre
+  @HasOne("bios") bio!: Bio
 }
 
 @Model()
 export class Book extends ApplicationRecord {
   static jsonapiType = "books"
 
-  @Attr title: string
+  @Attr title!: string
 
   @BelongsTo({ type: "genres" })
-  genre: Genre
+  genre!: Genre
   @HasOne({ type: Author })
   author: any
 }
@@ -89,7 +89,7 @@ export const NonFictionAuthor = Author.extend({
 export class Genre extends ApplicationRecord {
   static jsonapiType = "genres"
 
-  @Attr name: string
+  @Attr name!: string
   @HasMany("authors") authors: any
 }
 
@@ -97,14 +97,14 @@ export class Genre extends ApplicationRecord {
 export class Bio extends ApplicationRecord {
   static jsonapiType = "bios"
 
-  @Attr description: string
+  @Attr description!: string
 }
 
 @Model()
 export class Tag extends ApplicationRecord {
   static jsonapiType = "tags"
 
-  @Attr name: string
+  @Attr name!: string
 }
 
 @Model()

--- a/test/integration/authorization.test.ts
+++ b/test/integration/authorization.test.ts
@@ -22,7 +22,7 @@ let Author: typeof SpraypaintBase
 
 /*
  * This is annoying, but since mocha runs its `beforeEach` blocks from the outside in,
- * there are a couple tests we need to be able to reinstantiate the model classes from 
+ * there are a couple tests we need to be able to reinstantiate the model classes from
  * scratch for.  This is because loading JWT from localStorage happens when the model
  * class is created. This means we need to create those classes AFTER the localStorage
  * stubbing has happened. In those tests we will re-run the model instantiation after
@@ -41,7 +41,7 @@ const buildModels = () => {
     jsonapiType: "people"
   })
   class A extends ApplicationRecord {
-    @Attr nilly: string
+    @Attr nilly!: string
   }
   Author = A
 

--- a/test/integration/persistence.test.ts
+++ b/test/integration/persistence.test.ts
@@ -266,7 +266,7 @@ describe("Model persistence", () => {
 
         fetchMock.mock({
           matcher: "http://example.com/api/v1/people/1",
-          response: new Response({ status: 204 })
+          response: new Response({ status: 204 } as any)
         })
       })
 
@@ -288,7 +288,7 @@ describe("Model persistence", () => {
 
         fetchMock.mock({
           matcher: "http://example.com/api/v1/people/1",
-          response: new Response({ status: 202 })
+          response: new Response({ status: 202 } as any)
         })
       })
 

--- a/test/tshook.js
+++ b/test/tshook.js
@@ -1,4 +1,5 @@
 require("ts-node").register({
+  typeCheck: true,
   compilerOptions: {
     module: "commonjs"
   }

--- a/test/unit/decorators.test.ts
+++ b/test/unit/decorators.test.ts
@@ -99,7 +99,7 @@ describe("Decorators", () => {
         @Model()
         class TestClass extends BaseModel {
           @Attr({ type: String })
-          testField: string
+          testField!: string
         }
 
         expect(TestClass.attributeList.testField).to.include({
@@ -113,7 +113,7 @@ describe("Decorators", () => {
         @Model()
         class TestClass extends BaseModel {
           @Attr({ type: String })
-          testField: string
+          testField!: string
         }
 
         expect(TestClass.attributeList.testField).to.include({
@@ -128,7 +128,7 @@ describe("Decorators", () => {
       it("sets up the attribute correctly", () => {
         @Model()
         class TestClass extends BaseModel {
-          @Attr testField: string
+          @Attr testField!: string
         }
 
         expect(TestClass.attributeList.testField).to.include({

--- a/test/unit/model-class-typings.test.ts
+++ b/test/unit/model-class-typings.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "../test-helper"
 import { SpraypaintBase, Model, Scope, attr } from "../../src/index"
+import { KeyCase } from "../../src/model"
 import {
   WhereClause,
   SortScope,
@@ -8,8 +9,7 @@ import {
   IncludeScope,
   StatsScope
 } from "../../src/scope"
-import { RecordProxy } from "../../src/proxies/record-proxy"
-import { CollectionProxy } from "../../src/proxies/collection-proxy"
+import { NullProxy, CollectionProxy, RecordProxy } from '../../src/proxies';
 
 /*
  *
@@ -20,7 +20,7 @@ import { CollectionProxy } from "../../src/proxies/collection-proxy"
  * class methods on their type definitions.  This will not
  * cause the tests to fail, but it will prevent the type
  * checks from succeeding.
- * 
+ *
  */
 @Model()
 class ClassBasedRoot extends SpraypaintBase {}
@@ -44,7 +44,6 @@ describe("Model Class static attributes typings", () => {
           const jsonapiType: string | undefined = RootClass.jsonapiType
           const endpoint: string = RootClass.endpoint
           const jwt: string | undefined = RootClass.jwt
-          const jwtLocalStorage: string | false = RootClass.jwtLocalStorage
           const keyCase: KeyCase = RootClass.keyCase
           const strictAttributes: boolean = RootClass.strictAttributes
         })
@@ -80,7 +79,7 @@ describe("Model Class static attributes typings", () => {
         })
 
         it("understands the scope finder methods", () => {
-          const first: () => Promise<RecordProxy<SpraypaintBase>> = RootClass.first
+          const first: () => Promise<RecordProxy<SpraypaintBase> | NullProxy> = RootClass.first
           const find: (id: string | number) => Promise<RecordProxy<SpraypaintBase>> =
             RootClass.find
           const all: () => Promise<CollectionProxy<SpraypaintBase>> = RootClass.all

--- a/test/unit/model.test.ts
+++ b/test/unit/model.test.ts
@@ -226,9 +226,9 @@ describe("Model", () => {
 
       @Model()
       class Post extends BaseModel {
-        @Attr title: string
+        @Attr title!: string
         @BelongsTo({ type: Person })
-        author: Person
+        author!: Person
 
         screamTitle(exclamationPoints: number): string {
           let loudness: string = ""
@@ -299,7 +299,7 @@ describe("Model", () => {
       describe("model inheritence", () => {
         @Model()
         class FrontPagePost extends Post {
-          @Attr() pageOrder: number
+          @Attr() pageOrder!: number
 
           isFirst() {
             return this.pageOrder === 1
@@ -484,7 +484,7 @@ describe("Model", () => {
       describe("inheritance with class-based declaration", () => {
         class ExtendedPost extends (<any>Post) {
           // @Attr pageOrder : number
-          pageOrder: number
+          pageOrder!: number
 
           isFirst() {
             return this.pageOrder === 1
@@ -1258,10 +1258,11 @@ describe("Model", () => {
   describe("#unlisten()", () => {
     let author: Author
     let book: Book
+    let removeListenerSpy: SinonSpy
 
     beforeEach(() => {
       ApplicationRecord.sync = true
-      sinon.spy(EventBus, "removeEventListener")
+      removeListenerSpy = sinon.spy(EventBus, "removeEventListener")
       book = new Book({ id: 1 })
       book.isPersisted = true
       author = new Author({ id: 1, books: [book] })
@@ -1269,12 +1270,12 @@ describe("Model", () => {
     })
 
     afterEach(() => {
-      EventBus.removeEventListener.restore()
+      (removeListenerSpy).restore()
     })
 
     it("removes event listener from self + relationships", () => {
       author.unlisten()
-      expect(EventBus.removeEventListener.callCount).to.eq(2)
+      sinon.assert.callCount(removeListenerSpy, 2)
     })
 
     describe("when sync option is false", () => {
@@ -1285,27 +1286,28 @@ describe("Model", () => {
 
       it("does nothing", () => {
         author.unlisten()
-        expect(EventBus.removeEventListener.callCount).to.eq(0)
+        sinon.assert.callCount(removeListenerSpy, 0)
       })
     })
   })
 
   describe("#listen()", () => {
     let author: Author
+    let addListenerSpy: SinonSpy
 
     beforeEach(() => {
       ApplicationRecord.sync = true
-      sinon.spy(EventBus, "addEventListener")
+      addListenerSpy = sinon.spy(EventBus, "addEventListener")
       author = new Author()
     })
 
     afterEach(() => {
-      EventBus.addEventListener.restore()
+      addListenerSpy.restore()
     })
 
     it("adds event listener", () => {
       author.listen()
-      expect(EventBus.addEventListener.callCount).to.eq(1)
+      sinon.assert.callCount(addListenerSpy, 1)
     })
 
     describe("when sync option is false", () => {
@@ -1316,7 +1318,7 @@ describe("Model", () => {
 
       it("does nothing", () => {
         author.listen()
-        expect(EventBus.addEventListener.callCount).to.eq(0)
+        sinon.assert.callCount(addListenerSpy, 0)
       })
     })
   })
@@ -1325,11 +1327,11 @@ describe("Model", () => {
     @Model()
     class RelationGraph extends ApplicationRecord {
       @BelongsTo({ type: Author })
-      author: Author
+      author!: Author
       @HasMany({ type: Book })
-      books: Book
+      books!: Book
       @HasOne({ type: Bio })
-      bio: Bio
+      bio!: Bio
     }
 
     let instance: RelationGraph

--- a/test/unit/write-payload.test.ts
+++ b/test/unit/write-payload.test.ts
@@ -5,7 +5,7 @@ import { Person, PersonWithDasherizedKeys } from "../fixtures"
 describe("WritePayload", () => {
   it("underscores attributes", () => {
     let person = new Person({ first_name: "Joe" })
-    let payload = new WritePayload(person, true)
+    let payload = new WritePayload(person)
     expect(payload.asJSON()).to.deep.equal({
       data: {
         type: "people",
@@ -18,7 +18,7 @@ describe("WritePayload", () => {
 
   it("dasherizes attributes", () => {
     let person = new PersonWithDasherizedKeys({ first_name: "Joe" })
-    let payload = new WritePayload(person, true)
+    let payload = new WritePayload(person,)
     expect(payload.asJSON()).to.deep.equal({
       data: {
         type: "people",


### PR DESCRIPTION
This gets everything working on newer versions of typescript, with the
unfortunate tradeoff of removing support of all versions before 2.8.
Due to some changes in 2.9 we need to take advantage of some type
extraction utilities that are introduced in version 2.8 to make all of
our generics compatible.  Seems worth it though since we get everything
working with modern TS and this is part of a renamed library with a
separate major versioning scheme.

Also adds the `yarn test:all-versions` which will test against every
published version of typescript in the supported range.