### PR TITLE
Use correct content type

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -672,8 +672,8 @@ export class SpraypaintBase {
   static fetchOptions(): RequestInit {
     const options = {
       headers: {
-        Accept: "application/json",
-        ["Content-Type"]: "application/json"
+        Accept: "application/vnd.api+json",
+        ["Content-Type"]: "application/vnd.api+json"
       } as any
     }
 

--- a/test/integration/fetch-middleware.test.ts
+++ b/test/integration/fetch-middleware.test.ts
@@ -168,8 +168,8 @@ describe("fetch middleware", () => {
           expect(before.url).to.eq("http://example.com/api/v1/authors")
           expect(before.options).to.deep.eq({
             headers: {
-              Accept: "application/json",
-              "Content-Type": "application/json",
+              Accept: "application/vnd.api+json",
+              "Content-Type": "application/vnd.api+json",
               "CUSTOM-HEADER": "whatever"
             },
             method: "GET"
@@ -342,9 +342,9 @@ describe("fetch middleware", () => {
           expect(before.url).to.eq("http://example.com/api/v1/authors")
           expect(before.options).to.deep.eq({
             headers: {
-              Accept: "application/json",
+              Accept: "application/vnd.api+json",
               "CUSTOM-HEADER": "whatever",
-              "Content-Type": "application/json"
+              "Content-Type": "application/vnd.api+json"
             },
             body: JSON.stringify({ data: { type: "authors" } }),
             method: "POST"

--- a/test/unit/model.test.ts
+++ b/test/unit/model.test.ts
@@ -1508,8 +1508,8 @@ describe("Model", () => {
 
     it("includes the content headers", () => {
       const headers: any = Author.fetchOptions().headers
-      expect(headers.Accept).to.eq("application/json")
-      expect(headers["Content-Type"]).to.eq("application/json")
+      expect(headers.Accept).to.eq("application/vnd.api+json")
+      expect(headers["Content-Type"]).to.eq("application/vnd.api+json")
     })
   })
 })


### PR DESCRIPTION
The spec requires use of `application/vnd.api+json` in the
`Content-Type` and `Accept` headers.