### PR TITLE
Allow data lookup in persistence operations

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -81,7 +81,7 @@ export type ModelAttributeChangeSet<
   T extends SpraypaintBase
 > = ModelAttrChanges<Omit<T, keyof SpraypaintBase>>
 
-export interface SaveOptions<T extends typeof SpraypaintBase> {
+export interface SaveOptions<T extends SpraypaintBase> {
   with?: IncludeScope
   returnScope?: Scope<T>
 }
@@ -742,7 +742,9 @@ export class SpraypaintBase {
     this._middlewareStack = stack
   }
 
-  static scope<I extends typeof SpraypaintBase>(this: I): Scope<I> {
+  static scope<I extends typeof SpraypaintBase>(
+    this: I
+  ): Scope<I["prototype"]> {
     return new Scope(this)
   }
 
@@ -887,7 +889,7 @@ export class SpraypaintBase {
 
   async save<I extends SpraypaintBase>(
     this: I,
-    options: SaveOptions<I["klass"]> = {}
+    options: SaveOptions<I> = {}
   ): Promise<boolean> {
     let url = this.klass.url()
     let verb: RequestVerbs = "post"

--- a/src/model.ts
+++ b/src/model.ts
@@ -81,8 +81,9 @@ export type ModelAttributeChangeSet<
   T extends SpraypaintBase
 > = ModelAttrChanges<Omit<T, keyof SpraypaintBase>>
 
-export interface SaveOptions {
+export interface SaveOptions<T extends typeof SpraypaintBase> {
   with?: IncludeScope
+  returnScope?: Scope<T>
 }
 
 export type ExtendedModel<
@@ -884,7 +885,10 @@ export class SpraypaintBase {
     })
   }
 
-  async save(options: SaveOptions = {}): Promise<boolean> {
+  async save<I extends SpraypaintBase>(
+    this: I,
+    options: SaveOptions<I["klass"]> = {}
+  ): Promise<boolean> {
     let url = this.klass.url()
     let verb: RequestVerbs = "post"
     const request = new Request(this._middleware(), this.klass.logger)
@@ -894,6 +898,10 @@ export class SpraypaintBase {
     if (this.isPersisted) {
       url = this.klass.url(this.id)
       verb = "patch"
+    }
+
+    if (options.returnScope) {
+      url = `${url}?${options.returnScope.toQueryParams()}`
     }
 
     this.clearErrors()

--- a/src/model.ts
+++ b/src/model.ts
@@ -903,7 +903,15 @@ export class SpraypaintBase {
     }
 
     if (options.returnScope) {
-      url = `${url}?${options.returnScope.toQueryParams()}`
+      let scope = options.returnScope
+
+      if (scope.model !== this.klass) {
+        throw new Error(
+          `returnScope must be a scope of type Scope<${this.klass.name}>`
+        )
+      }
+
+      url = `${url}?${scope.toQueryParams()}`
     }
 
     this.clearErrors()

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -26,8 +26,7 @@ export class Person extends ApplicationRecord {
 
 @Model()
 export class PersonWithExtraAttr extends Person {
-  @Attr({ persist: false })
-  extraThing!: string
+  @Attr({ persist: false }) extraThing!: string
 }
 
 @Model({ keyCase: { server: "snake", client: "snake" } })
@@ -44,13 +43,11 @@ export class PersonWithDasherizedKeys extends Person {}
 })
 export class Author extends Person {
   @Attr nilly!: string
-  @HasMany({ type: "multi_words" })
-  multiWords!: MultiWord[]
+  @HasMany({ type: "multi_words" }) multiWords!: MultiWord[]
   @HasMany("books") specialBooks!: Book[]
   @HasMany() books!: Book[]
   @HasMany() tags!: Tag[]
-  @BelongsTo({ type: "genres" })
-  genre!: Genre
+  @BelongsTo({ type: "genres" }) genre!: Genre
   @HasOne("bios") bio!: Bio
 }
 

--- a/test/integration/finders.test.ts
+++ b/test/integration/finders.test.ts
@@ -286,6 +286,27 @@ describe("Model finders", () => {
       })
     })
 
+    describe("when value is a nested hash", () => {
+      beforeEach(() => {
+        fetchMock.reset()
+        fetchMock.get(
+          "http://example.com/api/v1/people?filter[id][not_eq]=1,2,3",
+          {
+            data: [{ id: "2", type: "people" }]
+          }
+        )
+      })
+
+      it("converts to comma-delimited string", async () => {
+        const { data } = await Person.where({
+          id: {
+            not_eq: [1, 2, 3]
+          }
+        }).all()
+        expect(data.length).to.eq(1)
+      })
+    })
+
     describe("when value is false", () => {
       beforeEach(() => {
         fetchMock.reset()

--- a/test/integration/persistence-with-return-scope.test.ts
+++ b/test/integration/persistence-with-return-scope.test.ts
@@ -1,6 +1,5 @@
 import { expect, fetchMock } from "../test-helper"
-import { Author, Book } from "../fixtures"
-import { JsonapiRequestDoc, JsonapiResponseDoc } from "../../src/index"
+import { Author } from "../fixtures"
 
 const resetMocks = () => {
   fetchMock.restore()

--- a/test/integration/persistence-with-return-scope.test.ts
+++ b/test/integration/persistence-with-return-scope.test.ts
@@ -1,0 +1,111 @@
+import { expect, fetchMock } from "../test-helper"
+import { Author, Book } from "../fixtures"
+import { JsonapiRequestDoc, JsonapiResponseDoc } from "../../src/index"
+
+const resetMocks = () => {
+  fetchMock.restore()
+}
+
+after(() => {
+  resetMocks()
+})
+
+function generateMockResponse() {
+  return {
+    data: {
+      id: "1",
+      type: "authors",
+      attributes: {
+        first_name: "John",
+        nilly: "Foobar"
+      },
+      relationships: {
+        books: {
+          data: [
+            {
+              id: "book1",
+              type: "books"
+            },
+            {
+              id: "book3",
+              type: "books"
+            }
+          ]
+        }
+      }
+    },
+    included: [
+      {
+        id: "book1",
+        type: "books",
+        attributes: {
+          title: "The Shining"
+        }
+      },
+      {
+        id: "book3",
+        type: "books",
+        attributes: {
+          title: "Alice in Wonderland"
+        }
+      }
+    ]
+  } as any
+}
+
+describe("Lookup additional data during persistence operation", () => {
+  beforeEach(() => {
+    resetMocks()
+  })
+
+  describe("#save()", () => {
+    describe("when creating a new record", () => {
+      beforeEach(() => {
+        fetchMock.post(
+          "http://example.com/api/v1/authors?extra_fields[authors]=nilly&include=books",
+          generateMockResponse()
+        )
+      })
+
+      it("accepts a scope for looking up additional items", async () => {
+        let author = new Author({
+          firstName: "Steven"
+        })
+
+        let returnScope = Author.includes("books").selectExtra(["nilly"])
+
+        await author.save({ returnScope })
+
+        expect(author.nilly).to.eq("Foobar")
+        expect(author.books.length).to.eq(2)
+        expect(author.books[0].title).to.eq("The Shining")
+      })
+    })
+
+    describe("when updating an existing record", () => {
+      beforeEach(() => {
+        fetchMock.patch(
+          "http://example.com/api/v1/authors/1?extra_fields[authors]=nilly&include=books",
+          generateMockResponse()
+        )
+      })
+
+      it("accepts a scope for looking up additional items", async () => {
+        let author = new Author({
+          id: "1",
+          firstName: "Steven"
+        })
+
+        author.isPersisted = true
+
+        let returnScope = Author.includes("books").selectExtra(["nilly"])
+
+        await author.save({ returnScope })
+
+        expect(author.nilly).to.eq("Foobar")
+        expect(author.books.length).to.eq(2)
+        expect(author.books[0].title).to.eq("The Shining")
+      })
+    })
+  })
+})

--- a/test/integration/persistence-with-return-scope.test.ts
+++ b/test/integration/persistence-with-return-scope.test.ts
@@ -1,5 +1,5 @@
-import { expect, fetchMock } from "../test-helper"
-import { Author } from "../fixtures"
+import { expect, fetchMock, sinon } from "../test-helper"
+import { Author, Person } from "../fixtures"
 
 const resetMocks = () => {
   fetchMock.restore()
@@ -78,6 +78,23 @@ describe("Lookup additional data during persistence operation", () => {
         expect(author.nilly).to.eq("Foobar")
         expect(author.books.length).to.eq(2)
         expect(author.books[0].title).to.eq("The Shining")
+      })
+
+      it.only("raises an error if a scope for a different model is passed", async () => {
+        let person = new Person({
+          firstName: "Steven"
+        })
+
+        let returnScope = Author.includes("books").selectExtra(["nilly"])
+
+        try {
+          await person.save({ returnScope })
+          expect(true).to.eq(false)
+        } catch (err) {
+          expect(err.message).to.match(
+            /returnScope must be a scope of type Scope<Person>/
+          )
+        }
       })
     })
 

--- a/test/unit/model-class-typings.test.ts
+++ b/test/unit/model-class-typings.test.ts
@@ -32,64 +32,109 @@ const ExtendBasedRoot = SpraypaintBase.extend({
 })
 
 describe("Model Class static attributes typings", () => {
-  ;[
-    { RootClass: ClassBasedRoot, name: "Class-Based" },
-    { RootClass: ExtendBasedRoot, name: "extend()-Based" }
-  ].forEach(({ RootClass, name }) => {
-    describe(name, () => {
-      describe("configuration options", () => {
-        it("has the correct types", () => {
-          const baseUrl: string = RootClass.baseUrl
-          const apiNamespace: string = RootClass.apiNamespace
-          const jsonapiType: string | undefined = RootClass.jsonapiType
-          const endpoint: string = RootClass.endpoint
-          const jwt: string | undefined = RootClass.jwt
-          const keyCase: KeyCase = RootClass.keyCase
-          const strictAttributes: boolean = RootClass.strictAttributes
-        })
+  describe("Class-Based", () => {
+    describe("configuration options", () => {
+      it("has the correct types", () => {
+        const baseUrl: string = ClassBasedRoot.baseUrl
+        const apiNamespace: string = ClassBasedRoot.apiNamespace
+        const jsonapiType: string | undefined = ClassBasedRoot.jsonapiType
+        const endpoint: string = ClassBasedRoot.endpoint
+        const jwt: string | undefined = ClassBasedRoot.jwt
+        const keyCase: KeyCase = ClassBasedRoot.keyCase
+        const strictAttributes: boolean = ClassBasedRoot.strictAttributes
+      })
+    })
+
+    const strEnum = <T extends string>(o: T[]): { [K in T]: K } => {
+      return o.reduce((res, key) => {
+        res[key] = key
+        return res
+      }, Object.create(null))
+    }
+
+    describe("Scope delegators", () => {
+      it("understands all of the scope delegator methods", () => {
+        const page: (num: number) => Scope<ClassBasedRoot> = ClassBasedRoot.page
+        const per: (num: number) => Scope<ClassBasedRoot> = ClassBasedRoot.per
+        const where: (opts: WhereClause) => Scope<ClassBasedRoot> =
+          ClassBasedRoot.where
+        const order: (opts: SortScope) => Scope<ClassBasedRoot> =
+          ClassBasedRoot.order
+        const select: (opts: FieldArg) => Scope<ClassBasedRoot> =
+          ClassBasedRoot.select
+        const selectExtra: (opts: FieldArg) => Scope<ClassBasedRoot> =
+          ClassBasedRoot.selectExtra
+        const includes: (opts: IncludeScope) => Scope<ClassBasedRoot> =
+          ClassBasedRoot.includes
+        const merge: (opts: Record<string, Scope>) => Scope<ClassBasedRoot> =
+          ClassBasedRoot.merge
+        const stats: (opts: StatsScope) => Scope<ClassBasedRoot> =
+          ClassBasedRoot.stats
       })
 
-      const strEnum = <T extends string>(o: T[]): { [K in T]: K } => {
-        return o.reduce((res, key) => {
-          res[key] = key
-          return res
-        }, Object.create(null))
-      }
+      it("understands the scope finder methods", () => {
+        const first: () => Promise<RecordProxy<SpraypaintBase> | NullProxy> =
+          ClassBasedRoot.first
+        const find: (
+          id: string | number
+        ) => Promise<RecordProxy<SpraypaintBase>> = ClassBasedRoot.find
+        const all: () => Promise<CollectionProxy<SpraypaintBase>> =
+          ClassBasedRoot.all
 
-      describe("Scope delegators", () => {
-        it("understands all of the scope delegator methods", () => {
-          const page: (num: number) => Scope<typeof RootClass> = RootClass.page
-          const per: (num: number) => Scope<typeof RootClass> = RootClass.per
-          const where: (opts: WhereClause) => Scope<typeof RootClass> =
-            RootClass.where
-          const order: (opts: SortScope) => Scope<typeof RootClass> =
-            RootClass.order
-          const select: (opts: FieldArg) => Scope<typeof RootClass> =
-            RootClass.select
-          const selectExtra: (opts: FieldArg) => Scope<typeof RootClass> =
-            RootClass.selectExtra
-          const includes: (opts: IncludeScope) => Scope<typeof RootClass> =
-            RootClass.includes
-          const merge: (
-            opts: Record<string, Scope>
-          ) => Scope<typeof RootClass> = RootClass.merge
-          const stats: (opts: StatsScope) => Scope<typeof RootClass> =
-            RootClass.stats
-        })
+        const result = new ExtendBasedRoot()
 
-        it("understands the scope finder methods", () => {
-          const first: () => Promise<RecordProxy<SpraypaintBase> | NullProxy> =
-            RootClass.first
-          const find: (
-            id: string | number
-          ) => Promise<RecordProxy<SpraypaintBase>> = RootClass.find
-          const all: () => Promise<CollectionProxy<SpraypaintBase>> =
-            RootClass.all
+        result.stringProp = "foo"
+      })
+    })
+  })
 
-          const result = new ExtendBasedRoot()
+  describe("extend()-Based", () => {
+    describe("configuration options", () => {
+      it("has the correct types", () => {
+        const baseUrl: string = ExtendBasedRoot.baseUrl
+        const apiNamespace: string = ExtendBasedRoot.apiNamespace
+        const jsonapiType: string | undefined = ExtendBasedRoot.jsonapiType
+        const endpoint: string = ExtendBasedRoot.endpoint
+        const jwt: string | undefined = ExtendBasedRoot.jwt
+        const keyCase: KeyCase = ExtendBasedRoot.keyCase
+        const strictAttributes: boolean = ExtendBasedRoot.strictAttributes
+      })
+    })
 
-          result.stringProp = "foo"
-        })
+    const strEnum = <T extends string>(o: T[]): { [K in T]: K } => {
+      return o.reduce((res, key) => {
+        res[key] = key
+        return res
+      }, Object.create(null))
+    }
+
+    describe("Scope delegators", () => {
+      it("understands all of the scope delegator methods", () => {
+        const page: (num: number) => Scope = ExtendBasedRoot.page
+        const per: (num: number) => Scope = ExtendBasedRoot.per
+        const where: (opts: WhereClause) => Scope = ExtendBasedRoot.where
+        const order: (opts: SortScope) => Scope = ExtendBasedRoot.order
+        const select: (opts: FieldArg) => Scope = ExtendBasedRoot.select
+        const selectExtra: (opts: FieldArg) => Scope =
+          ExtendBasedRoot.selectExtra
+        const includes: (opts: IncludeScope) => Scope = ExtendBasedRoot.includes
+        const merge: (opts: Record<string, Scope>) => Scope =
+          ExtendBasedRoot.merge
+        const stats: (opts: StatsScope) => Scope = ExtendBasedRoot.stats
+      })
+
+      it("understands the scope finder methods", () => {
+        const first: () => Promise<RecordProxy<SpraypaintBase> | NullProxy> =
+          ExtendBasedRoot.first
+        const find: (
+          id: string | number
+        ) => Promise<RecordProxy<SpraypaintBase>> = ExtendBasedRoot.find
+        const all: () => Promise<CollectionProxy<SpraypaintBase>> =
+          ExtendBasedRoot.all
+
+        const result = new ExtendBasedRoot()
+
+        result.stringProp = "foo"
       })
     })
   })

--- a/test/unit/scope.test.ts
+++ b/test/unit/scope.test.ts
@@ -1,8 +1,9 @@
 import { expect, sinon } from "../test-helper"
 import { Scope } from "../../src/scope"
-import { Author } from "../fixtures"
+import { Author, Book } from "../fixtures"
+import { SpraypaintBase } from "../../src"
 
-let scope: Scope<typeof Author>
+let scope: Scope<Author>
 
 beforeEach(() => {
   const model = sinon.stub() as any
@@ -298,6 +299,13 @@ describe("Scope", () => {
 
       expect(original._sort).not.to.eq(copy._sort)
       expect(original._sort).to.deep.eq(copy._sort)
+    })
+  })
+
+  describe("typings", () => {
+    it("correctly compiles the types", () => {
+      let authorScope: Scope<Author> = Author.scope()
+      let genericScope: Scope<SpraypaintBase> = Author.scope()
     })
   })
 })


### PR DESCRIPTION
Graphiti now supports the ability to pass a lookup scope as part of a
data persistence operation and the additional data will be returned in
the response.  This wires up the necessary things in Spraypaint to be
able to take advantage.  Now you may pass a `returnScope` parameter to
any `save()` call:

```
let result = await Employee.find(1)
let employee = result.data

employee.firstName = 'Steve'
await employee.save({
  returnScope: Employee.include(['department'])
})

console.log(employee.department.name) // => "Engineering"
```