### PR TITLE
Get tc39 decorators working

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prebuild": "yarn run clean && yarn test && yarn lint:ci",
     "build": "npm-run-all build:node build:es6 build:copy_shims build:umd build:umd:min",
     "build:node": "yarn run tsc -p ./tsconfig.node.json",
-    "build:es6": "yarn run tsc -p ./tsconfig.lib.json",
+    "build:es6": "yarn run tsc -p ./tsconfig.lib.json && yarn test:es6-compatibility",
     "build:umd": "yarn run rollup -c",
     "build:umd:min": "NODE_ENV=production yarn build:umd",
     "build:watch": "NODE_ENV=watch yarn build:es6 --watch",
@@ -23,6 +23,7 @@
     "test": "NODE_ENV=test mocha --opts test/mocha.opts",
     "test:watch": "yarn run test --watch",
     "test:all-versions": "yarn tav",
+    "test:es6-compatibility": "mocha --opts test/es6-compatibility/mocha.opts",
     "lint": "yarn run lint:ci --fix",
     "lint:ci": "yarn run eslint {src,test}{,/**}/*.ts",
     "update:dependencies": "ncu -u",
@@ -55,6 +56,13 @@
     "tslib": "^1.8.1"
   },
   "devDependencies": {
+    "@babel/cli": "7.2.3",
+    "@babel/core": "7.2.2",
+    "@babel/plugin-proposal-class-properties": "7.3.0",
+    "@babel/plugin-proposal-decorators": "7.3.0",
+    "@babel/plugin-transform-modules-commonjs": "7.2.0",
+    "@babel/preset-env": "7.3.1",
+    "@babel/register": "7.0.0",
     "@types/chai": "^4.0.4",
     "@types/chai-as-promised": "^7.1.0",
     "@types/chai-things": "^0.0.32",
@@ -95,7 +103,7 @@
     "sinon-chai": "2.14.0",
     "test-all-versions": "3.3.3",
     "ts-node": "4.0.1",
-    "typescript": "3.0.3",
+    "typescript": "3.2.4",
     "typescript-eslint-parser": "21.0.2",
     "winston": "^2.3.1"
   }

--- a/test/es6-compatibility/decorators.test.mjs
+++ b/test/es6-compatibility/decorators.test.mjs
@@ -1,0 +1,40 @@
+import {
+  SpraypaintBase,
+  Model,
+  Attr,
+  HasMany,
+  HasOne,
+  BelongsTo
+} from "../../lib-esm"
+import { expect } from "chai"
+
+describe("Decorators work with ES6/Babel", () => {
+  describe("@Model()", () => {
+    it("creates the models correctly", () => {
+      @Model({})
+      class ApplicationRecord extends SpraypaintBase {}
+
+      @Model({ jsonapiType: "users" })
+      class User extends ApplicationRecord {
+        @Attr name
+        @HasMany post
+        @HasOne({ type: User }) supervisor
+      }
+
+      @Model({ jsonapiType: "posts" })
+      class Post extends ApplicationRecord {
+        @Attr title
+        @BelongsTo author
+      }
+
+      expect(ApplicationRecord.parentClass).to.eq(SpraypaintBase)
+      expect(ApplicationRecord.typeRegistry.get("users")).to.eq(User)
+      expect(Object.keys(User.attributeList)).to.deep.eq([
+        "name",
+        "post",
+        "supervisor"
+      ])
+      expect(Object.keys(Post.attributeList)).to.deep.eq(["title", "author"])
+    })
+  })
+})

--- a/test/es6-compatibility/mocha.opts
+++ b/test/es6-compatibility/mocha.opts
@@ -1,0 +1,3 @@
+--require test/es6-compatibility/test-setup.js
+--watch-extensions mjs
+test/es6-compatibility/**/*.test.{m,}js

--- a/test/es6-compatibility/test-setup.js
+++ b/test/es6-compatibility/test-setup.js
@@ -1,0 +1,8 @@
+require("@babel/register")({
+  ignore: [],
+  plugins: [
+    ["@babel/plugin-proposal-decorators", { decoratorsBeforeExport: true }],
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-transform-modules-commonjs"
+  ]
+})


### PR DESCRIPTION
When the decorators were first setup, typescript and Babel had the same
API for implementing decorators.  Since then, TC39 has [evolved the
decorator API](https://github.com/tc39/proposal-decorators/blob/76af727310703b8d650d0f94220fa770a403a6bd/DETAILS.md).  This adds compatibility with the newer decorators.
Additionally, it adds an es6 compatibility smoke suite which will run
after the ESM module build.

The decorators code is getting pretty hairy with a number of code paths,
so I'd like to clean it up, but this at least gets it working an
unblocks a few users who are working in a modern babel setup.