### PR TITLE
Allow Number types not to write empty string

### DIFF
--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -22,6 +22,7 @@ export class Person extends ApplicationRecord {
 
   @Attr firstName!: string | null
   @Attr lastName!: string | null
+  @Attr({ type: Number }) age!: number | null
 }
 
 @Model()

--- a/test/unit/write-payload.test.ts
+++ b/test/unit/write-payload.test.ts
@@ -3,6 +3,23 @@ import { WritePayload } from "../../src/util/write-payload"
 import { Person, PersonWithDasherizedKeys } from "../fixtures"
 
 describe("WritePayload", () => {
+  it("Does not serialize number attributes as empty string", () => {
+    let person = new Person({ first_name: "Joe", age: 23 })
+    ;(person.age as any) = ""
+    person.lastName = ""
+    let payload = new WritePayload(person)
+    expect(payload.asJSON()).to.deep.equal({
+      data: {
+        type: "people",
+        attributes: {
+          first_name: "Joe",
+          last_name: "",
+          age: null
+        }
+      }
+    })
+  })
+
   it("underscores attributes", () => {
     let person = new Person({ first_name: "Joe" })
     let payload = new WritePayload(person)


### PR DESCRIPTION
Previously there was an issue when binding a Spraypaint model to a form
or otherwise allowing a number field to be set to an empty string.  This
would pass down to the backend and Graphiti would (correctly) blow up,
as it was receiving a string but expecting a number (or null, in this
case).  This will obey specyfing `Attr({type: Number})` in the model
definition.  When this receives an empty string during payload
serialization, it will write `null` instead.

This is a quick fix to a specific user problem.  There is a bigger
commit that needs to happen here with casting & payload
serialization/deserialization, but I'd like to get this in to fix the
immediate concern for now.

This addresses the concerns raised in https://github.com/graphiti-api/graphiti/pull/68
and moves the logic to the client, where it probably should be handled.