### PR TITLE
Support links as indicated in JSON:API specification

### DIFF
--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -165,11 +165,24 @@ const AttrDecoratorFactory: {
   }
 }
 
-const LinkDecoratorFactory = function(): any {
-  return (target: SpraypaintBase, propKey: string) => {
-    const ModelClass = <any>target.constructor
-    ensureModelInheritance(ModelClass)
-    ModelClass.linkList.push(propKey)
+const LinkDecoratorFactory = function(
+  fieldDetail?: FieldDecoratorDescriptor
+): any {
+  const trackLink = (Model: typeof SpraypaintBase, propKey: string) => {
+    ensureModelInheritance(Model)
+    Model.linkList.push(propKey)
+  }
+
+  if (isModernDecoratorDescriptor(fieldDetail)) {
+    return Object.assign(fieldDetail, {
+      finisher: (Model: typeof SpraypaintBase) => {
+        trackLink(Model, fieldDetail.key)
+      }
+    })
+  } else {
+    return (target: SpraypaintBase, propKey: string) => {
+      trackLink(<any>target.constructor, propKey)
+    }
   }
 }
 

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -165,6 +165,14 @@ const AttrDecoratorFactory: {
   }
 }
 
+const LinkDecoratorFactory = function(): any {
+  return (target: SpraypaintBase, propKey: string) => {
+    const ModelClass = <any>target.constructor
+    ensureModelInheritance(ModelClass)
+    ModelClass.linkList.push(propKey)
+  }
+}
+
 const ensureModelInheritance = (ModelClass: typeof SpraypaintBase) => {
   if (ModelClass.currentClass !== ModelClass) {
     ModelClass.currentClass.inherited(ModelClass)
@@ -319,6 +327,7 @@ const BelongsToDecoratorFactory = AssociationDecoratorFactoryBuilder(BelongsTo)
 export {
   ModelDecorator as Model,
   AttrDecoratorFactory as Attr,
+  LinkDecoratorFactory as Link,
   HasManyDecoratorFactory as HasMany,
   HasOneDecoratorFactory as HasOne,
   BelongsToDecoratorFactory as BelongsTo

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export { Attribute, attr } from "./attribute"
 
 export { hasMany, hasOne, belongsTo } from "./associations"
 
-export { Model, Attr, HasMany, HasOne, BelongsTo } from "./decorators"
+export { Model, Attr, HasMany, HasOne, BelongsTo, Link } from "./decorators"
 
 export { MiddlewareStack } from "./middleware-stack"
 

--- a/src/util/deserialize.ts
+++ b/src/util/deserialize.ts
@@ -130,6 +130,9 @@ class Deserializer {
     // assign attrs
     instance.assignAttributes(datum.attributes)
 
+    // assign links
+    instance.assignLinks(datum.links)
+
     // assign meta
     instance.setMeta(datum.meta)
 

--- a/test/es6-compatibility/decorators.test.mjs
+++ b/test/es6-compatibility/decorators.test.mjs
@@ -4,7 +4,8 @@ import {
   Attr,
   HasMany,
   HasOne,
-  BelongsTo
+  BelongsTo,
+  Link
 } from "../../lib-esm"
 import { expect } from "chai"
 
@@ -27,6 +28,12 @@ describe("Decorators work with ES6/Babel", () => {
         @BelongsTo author
       }
 
+      @Model({ jsonapiType: "users_with_link" })
+      class UserWithLink extends ApplicationRecord {
+        @Attr name
+        @Link self
+      }
+
       expect(ApplicationRecord.parentClass).to.eq(SpraypaintBase)
       expect(ApplicationRecord.typeRegistry.get("users")).to.eq(User)
       expect(Object.keys(User.attributeList)).to.deep.eq([
@@ -35,6 +42,7 @@ describe("Decorators work with ES6/Babel", () => {
         "supervisor"
       ])
       expect(Object.keys(Post.attributeList)).to.deep.eq(["title", "author"])
+      expect(UserWithLink.linkList).to.deep.eq(["self"])
     })
   })
 })

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -32,6 +32,9 @@ export class PersonWithExtraAttr extends Person {
 
 @Model()
 export class PersonWithLinks extends Person {
+  static endpoint = "/v1/people_with_links"
+  static jsonapiType = "people_with_links"
+
   @Link() self!: string
   @Link() webView!: string
 }

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -7,7 +7,7 @@ import {
   hasOne
 } from "../src/index"
 
-import { Attr, BelongsTo, HasMany, HasOne } from "../src/decorators"
+import { Attr, BelongsTo, HasMany, HasOne, Link } from "../src/decorators"
 
 @Model({
   baseUrl: "http://example.com",
@@ -28,6 +28,12 @@ export class Person extends ApplicationRecord {
 @Model()
 export class PersonWithExtraAttr extends Person {
   @Attr({ persist: false }) extraThing!: string
+}
+
+@Model()
+export class PersonWithLinks extends Person {
+  @Link() self!: string
+  @Link() webView!: string
 }
 
 @Model({ keyCase: { server: "snake", client: "snake" } })

--- a/test/unit/decorators.test.ts
+++ b/test/unit/decorators.test.ts
@@ -188,6 +188,7 @@ describe("Decorators", () => {
 
       expect(ChildTestClass.linkList).to.include("link1")
       expect(ChildTestClass.linkList).to.include("link2")
+      expect(TestClass.linkList).to.not.include("link2")
     })
   })
 

--- a/test/unit/decorators.test.ts
+++ b/test/unit/decorators.test.ts
@@ -5,6 +5,7 @@ import {
   HasOne,
   HasMany,
   BelongsTo,
+  Link,
   initModel
 } from "../../src/decorators"
 import { Association } from "../../src/associations"
@@ -155,6 +156,39 @@ describe("Decorators", () => {
         })
       }
     )
+  })
+
+  describe("@Link", () => {
+    let BaseModel: typeof SpraypaintBase
+
+    beforeEach(() => {
+      @Model()
+      class MyBase extends SpraypaintBase {}
+      BaseModel = MyBase
+    })
+
+    it("adds to the link list", () => {
+      @Model()
+      class TestClass extends BaseModel {
+        @Link() link1!: string
+      }
+
+      expect(TestClass.linkList).to.include("link1")
+    })
+
+    it("child class adds to the link list of parent", () => {
+      @Model()
+      class TestClass extends BaseModel {
+        @Link() link1!: string
+      }
+
+      class ChildTestClass extends TestClass {
+        @Link() link2!: string
+      }
+
+      expect(ChildTestClass.linkList).to.include("link1")
+      expect(ChildTestClass.linkList).to.include("link2")
+    })
   })
 
   const singleDecorators = [

--- a/test/unit/model.test.ts
+++ b/test/unit/model.test.ts
@@ -1557,5 +1557,32 @@ describe("Model", () => {
       expect(author.links.webView).to.eq("/person/1")
       expect(author.links.undeclared).to.be.undefined
     })
+
+    describe("deserialize from payload correctly", () => {
+      const doc = {
+        data: {
+          id: "1",
+          type: "people_with_links",
+          attributes: { firstName: "Donald Budge" },
+          links: {
+            self: "/api/person/1",
+            web_view: "/person/1"
+          }
+        }
+      }
+
+      it("from instance", () => {
+        const person = new PersonWithLinks({ id: "1", firstName: "Stephen" })
+        person.fromJsonapi(doc.data, doc)
+        expect(person.links.self).to.eq("/api/person/1")
+        expect(person.links.webView).to.eq("/person/1")
+      })
+
+      it("from class", () => {
+        const person = PersonWithLinks.fromJsonapi(doc.data, doc)
+        expect(person.links.self).to.eq("/api/person/1")
+        expect(person.links.webView).to.eq("/person/1")
+      })
+    })
   })
 })

--- a/test/unit/model.test.ts
+++ b/test/unit/model.test.ts
@@ -15,6 +15,7 @@ import { EventBus } from "../../src/event-bus"
 import {
   ApplicationRecord,
   Person,
+  PersonWithLinks,
   Book,
   Author,
   Genre,
@@ -1528,6 +1529,33 @@ describe("Model", () => {
       const headers: any = Author.fetchOptions().headers
       expect(headers.Accept).to.eq("application/vnd.api+json")
       expect(headers["Content-Type"]).to.eq("application/vnd.api+json")
+    })
+  })
+
+  describe("links", () => {
+    it("duplicates the links when object is duplicated", () => {
+      let author = new PersonWithLinks({ id: "1", firstName: "Stephen" })
+      author.assignLinks({ self: "/api/person/1", web_view: "/person/1" })
+
+      let duped = author.dup()
+      duped.assignLinks({ self: "/api/humans/1" })
+
+      expect(author.links.self).to.eq("/api/person/1")
+      expect(author.links.webView).to.eq("/person/1")
+      expect(duped.links.self).to.eq("/api/humans/1")
+      expect(duped.links.webView).to.eq("/person/1")
+    })
+
+    it("discard links that are undeclared but included in payload", () => {
+      let author = new PersonWithLinks({ id: "1", firstName: "Stephen" })
+      author.assignLinks({
+        self: "/api/person/1",
+        web_view: "/person/1",
+        undeclared: "/something"
+      })
+      expect(author.links.self).to.eq("/api/person/1")
+      expect(author.links.webView).to.eq("/person/1")
+      expect(author.links.undeclared).to.be.undefined
     })
   })
 })

--- a/test/unit/model.test.ts
+++ b/test/unit/model.test.ts
@@ -1565,23 +1565,30 @@ describe("Model", () => {
           type: "people_with_links",
           attributes: { firstName: "Donald Budge" },
           links: {
-            self: "/api/person/1",
+            self: { href: "/api/person/1", meta: { count: 10 } },
             web_view: "/person/1"
           }
         }
       }
 
+      function assertPersonIsCorrect(person: PersonWithLinks) {
+        expect(person.links.self).to.deep.equal({
+          href: "/api/person/1",
+          meta: { count: 10 }
+        })
+        expect(person.links.webView).to.eq("/person/1")
+        expect(person.links.comments).to
+      }
+
       it("from instance", () => {
         const person = new PersonWithLinks({ id: "1", firstName: "Stephen" })
         person.fromJsonapi(doc.data, doc)
-        expect(person.links.self).to.eq("/api/person/1")
-        expect(person.links.webView).to.eq("/person/1")
+        assertPersonIsCorrect(person)
       })
 
       it("from class", () => {
         const person = PersonWithLinks.fromJsonapi(doc.data, doc)
-        expect(person.links.self).to.eq("/api/person/1")
-        expect(person.links.webView).to.eq("/person/1")
+        assertPersonIsCorrect(person)
       })
     })
   })


### PR DESCRIPTION
Solves #16 

Click [here](https://jsonapi.org/format/#document-resource-object-links) for the specifications related to links in JSON:API

This is my first time coding in Typescript so I may not use all the features it offers.

In order to use my new decorator, one would follow this:

```ts
@Model()
export class PersonWithLinks extends SpraypaintBase {
  static endpoint = "/v1/people_with_links"
  static jsonapiType = "people_with_links"
 
  @Link() self!: string
  @Link() webView!: string
}

const person = await PersonWithLinks.find(123)
// Assuming that the pay load is
// {
//   data: {
//     id: "123",
//     type: "people_with_links",
//     links: {
//       self: "/v1/people_with_links/123",
//       web_view: "/people_with_links/123"
//     }
//   }
// }

person.links.self // value is /v1/people_with_links/123
person.links.webView // value is /people_with_links/123
``` 