### PR TITLE
Add syncRelationships()

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -483,6 +483,15 @@ export class SpraypaintBase {
     if (val) this.reset()
   }
 
+  _onSyncRelationships?: (event: any, relationships: any) => void
+  private onSyncRelationships() {
+    if (this._onSyncRelationships) return this._onSyncRelationships
+    this._onSyncRelationships = (event, relationships) => {
+      this.relationships = relationships
+    }
+    return this._onSyncRelationships
+  }
+
   _onStoreChange?: (event: any, attrs: any) => void
   private onStoreChange() {
     if (this._onStoreChange) return this._onStoreChange
@@ -514,6 +523,10 @@ export class SpraypaintBase {
     if (!this.klass.sync) return
     if (this.storeKey) {
       EventBus.removeEventListener(this.storeKey, this.onStoreChange())
+      EventBus.removeEventListener(
+        `${this.storeKey}-sync-relationships`,
+        this.onSyncRelationships()
+      )
     }
 
     Object.keys(this.relationships).forEach(k => {
@@ -534,7 +547,19 @@ export class SpraypaintBase {
     if (!this._onStoreChange) {
       // not already registered
       EventBus.addEventListener(this.storeKey, this.onStoreChange())
+      EventBus.addEventListener(
+        `${this.storeKey}-sync-relationships`,
+        this.onSyncRelationships()
+      )
     }
+  }
+
+  syncRelationships(): void {
+    EventBus.dispatch(
+      `${this.storeKey}-sync-relationships`,
+      {},
+      this.relationships
+    )
   }
 
   reset(): void {

--- a/test/integration/id-map.test.ts
+++ b/test/integration/id-map.test.ts
@@ -143,6 +143,18 @@ describe("ID Map", () => {
         let author2 = (await Author.find(1)).data
         expect(author1.firstName).to.eq("updated")
       })
+
+      it("no longer sync on manual relationship sync", async () => {
+        let author1 = (await Author.find(1)).data
+        let book1 = new Book()
+        author1.books = [book1]
+        author1.unlisten()
+        let author2 = (await Author.find(1)).data
+        let book2 = new Book()
+        author2.books = [book2]
+        author2.syncRelationships()
+        expect(author1.books).to.eql([book1])
+      })
     })
 
     // A good way to think about this test:
@@ -183,6 +195,20 @@ describe("ID Map", () => {
       // now back to unsynced
       author1.firstName = "updated again"
       expect(author2.firstName).to.eq("updated")
+    })
+  })
+
+  describe("when manually syncing relationships", () => {
+    it("works", async () => {
+      let book1 = new Book()
+      let book2 = new Book()
+      let author1 = new Author({ id: 1, books: [book1] })
+      author1.isPersisted = true
+      let author2 = new Author({ id: 2, books: [book2] })
+      author2.isPersisted = true
+
+      author2.syncRelationships()
+      expect(author1.books).to.eql([book2])
     })
   })
 

--- a/test/unit/model.test.ts
+++ b/test/unit/model.test.ts
@@ -1286,7 +1286,7 @@ describe("Model", () => {
 
     it("removes event listener from self + relationships", () => {
       author.unlisten()
-      sinon.assert.callCount(removeListenerSpy, 2)
+      sinon.assert.callCount(removeListenerSpy, 4)
     })
 
     describe("when sync option is false", () => {
@@ -1318,7 +1318,7 @@ describe("Model", () => {
 
     it("adds event listener", () => {
       author.listen()
-      sinon.assert.callCount(addListenerSpy, 1)
+      sinon.assert.callCount(addListenerSpy, 2)
     })
 
     describe("when sync option is false", () => {


### PR DESCRIPTION
When doing [state syncing](https://www.graphiti.dev/js/state-syncing),
we wouldn't want to *automatically* sync relationships. If a Post A only
fetched comments matching text 'foo', we wouldn't want to Post B - which
adds a new comment without text 'foo' - to affect Post A's comments.

But there's still value in *manually* syncing relationships, when you're
aware of the issue but want things to sync-up in any case. You can now
do this with `#syncRelationships()`:

```ts
let author1 = await Author.find(1)
let author2 = await Author.find(1)
let book1 = new Book()
author2.books = [book1]
author2.syncRelationships()
author1.books # => [book1]
```