### PR TITLE
Provide a way to reset attribute changes

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -573,6 +573,10 @@ export class SpraypaintBase {
     )
   }
 
+  rollback(): void {
+    this._attributes = cloneDeep(this._originalAttributes)
+  }
+
   get isMarkedForDestruction(): boolean {
     return this._markedForDestruction
   }

--- a/test/integration/rollback.test.ts
+++ b/test/integration/rollback.test.ts
@@ -1,0 +1,37 @@
+import { expect, fetchMock } from "../test-helper"
+import { Author } from "../fixtures"
+
+describe("Rollback", () => {
+  let responsePayload = (firstName: string) => {
+    return {
+      data: {
+        id: "1",
+        type: "people",
+        attributes: { firstName }
+      }
+    }
+  }
+
+  afterEach(() => {
+    fetchMock.restore()
+  })
+
+  beforeEach(() => {
+    let url = "http://example.com/api/v1/authors"
+    fetchMock.post(url, responsePayload("John"))
+    fetchMock.patch(`${url}/1`, responsePayload("Jake"))
+  })
+
+  it("reverts changes to attributes", async () => {
+    const originalFirstName = "John"
+    let instance = new Author({ firstName: originalFirstName })
+    await instance.save()
+    expect(instance.isPersisted).to.eq(true)
+    expect(instance.isDirty()).to.eq(false)
+    instance.firstName = "Jake"
+    expect(instance.isDirty()).to.eq(true)
+    instance.rollback()
+    expect(instance.isDirty()).to.eq(false)
+    expect(instance.firstName).to.eq(originalFirstName)
+  })
+})


### PR DESCRIPTION
Hello there!

Previously the reset function overwrote the original attribute state with the current one making it a save() without a request and making all future calls to isDirty() invalid.

This should fix #21.