### PR TITLE
Handle response with status code 202 with potential background job details

### DIFF
--- a/src/deferred-action-callback.ts
+++ b/src/deferred-action-callback.ts
@@ -1,0 +1,3 @@
+export interface DeferredActionCallback {
+  (responseObject: any): void
+}

--- a/src/model.ts
+++ b/src/model.ts
@@ -904,7 +904,7 @@ export class SpraypaintBase {
     }
   }
 
-  async destroy(): Promise<boolean> {
+  async destroy(): Promise<any> {
     const url = this.klass.url(this.id)
     const verb = "delete"
     const request = new Request(this._middleware(), this.klass.logger)
@@ -914,6 +914,10 @@ export class SpraypaintBase {
       response = await request.delete(url, this._fetchOptions())
     } catch (err) {
       throw err
+    }
+
+    if (response.status === 202) {
+      return await this._handleAcceptedResponse(response)
     }
 
     let base = this.klass.baseClass as typeof SpraypaintBase
@@ -969,6 +973,17 @@ export class SpraypaintBase {
       )
       payload.postProcess()
     })
+  }
+
+  private async _handleAcceptedResponse(response: any): Promise<any> {
+    let returnValue = await this._handleResponse(response, () => {})
+    if (response.jsonPayload) {
+      returnValue = this.klass.fromJsonapi(
+        response.jsonPayload.data,
+        response.jsonPayload
+      )
+    }
+    return returnValue
   }
 
   private async _handleResponse(

--- a/src/model.ts
+++ b/src/model.ts
@@ -931,7 +931,7 @@ export class SpraypaintBase {
   async save<I extends SpraypaintBase>(
     this: I,
     options: SaveOptions<I> = {}
-  ): Promise<boolean> {
+  ): Promise<any> {
     let url = this.klass.url()
     let verb: RequestVerbs = "post"
     const request = new Request(this._middleware(), this.klass.logger)
@@ -963,6 +963,10 @@ export class SpraypaintBase {
       response = await request[verb](url, json, this._fetchOptions())
     } catch (err) {
       throw err
+    }
+
+    if (response.status === 202) {
+      return await this._handleAcceptedResponse(response)
     }
 
     return await this._handleResponse(response, () => {

--- a/src/request.ts
+++ b/src/request.ts
@@ -104,13 +104,14 @@ export class Request {
   ) {
     let wasDelete =
       requestOptions.method === "DELETE" &&
-      [202, 204, 200].indexOf(response.status) > -1
+      [204, 200].indexOf(response.status) > -1
     if (wasDelete) return
 
     let json
     try {
       json = await response.json()
     } catch (e) {
+      if (response.status === 202) return
       throw new ResponseError(response, "invalid json", e)
     }
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -119,6 +119,11 @@ export class MultiWord extends ApplicationRecord {
   static jsonapiType = "multi_words"
 }
 
+@Model()
+export class BackgroundJob extends ApplicationRecord {
+  static jsonapiType = "background_jobs"
+}
+
 export const TestJWTSubclass = ApplicationRecord.extend({})
 
 export const NonJWTOwner = SpraypaintBase.extend({})

--- a/test/integration/persistence.test.ts
+++ b/test/integration/persistence.test.ts
@@ -274,8 +274,13 @@ describe("Model persistence", () => {
       })
 
       it("deserialize the response and return the job object", async () => {
+        let job: BackgroundJob = new BackgroundJob()
+        let populateJobOnResponse = (response: any) => {
+          job = response
+        }
+        instance.onDeferredUpdate = populateJobOnResponse
         expect(instance.isPersisted).to.eq(false)
-        const job = await instance.save()
+        await instance.save()
 
         expect(instance.isPersisted).to.eq(false)
         expect(job.id).to.eq("23")
@@ -360,8 +365,13 @@ describe("Model persistence", () => {
       })
 
       it("deserialize the response and return the job object", async () => {
+        let job: BackgroundJob = new BackgroundJob()
+        let populateJobOnResponse = (response: any) => {
+          job = response
+        }
+        instance.onDeferredDestroy = populateJobOnResponse
         expect(instance.isPersisted).to.eq(true)
-        const job = await instance.destroy()
+        await instance.destroy()
 
         expect(instance.isPersisted).to.eq(true)
         expect(job.id).to.eq("23")


### PR DESCRIPTION
Close #23 

Per the specification of JSON:API, if the server respond with 202 then that means it doesn't actually save or delete the resource yet. So the flag `isPersisted` should not change on the object.