### PR TITLE
Allow POST with _method PATCH

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -163,6 +163,7 @@ export class SpraypaintBase {
   static logger: ILogger = defaultLogger
   static sync: boolean = false
   static clientApplication: string | null = null
+  static patchAsPost: boolean = false
 
   static attributeList: Record<string, Attribute> = {}
   static linkList: Array<string> = []
@@ -930,7 +931,9 @@ export class SpraypaintBase {
   ): Promise<boolean> {
     let url = this.klass.url()
     let verb: RequestVerbs = "post"
-    const request = new Request(this._middleware(), this.klass.logger)
+    const request = new Request(this._middleware(), this.klass.logger, {
+      patchAsPost: this.klass.patchAsPost
+    })
     const payload = new WritePayload(this, options.with)
     let response: any
 

--- a/src/util/write-payload.ts
+++ b/src/util/write-payload.ts
@@ -106,8 +106,8 @@ export class WritePayload<T extends SpraypaintBase> {
             if (
               !this._isNewAndMarkedForDestruction(relatedModel) &&
               (idOnly ||
-              this.model.hasDirtyRelation(key, relatedModel) ||
-              relatedModel.isDirty(nested))
+                this.model.hasDirtyRelation(key, relatedModel) ||
+                relatedModel.isDirty(nested))
             ) {
               data.push(this._processRelatedModel(relatedModel, nested, idOnly))
             }
@@ -121,8 +121,8 @@ export class WritePayload<T extends SpraypaintBase> {
           if (
             !this._isNewAndMarkedForDestruction(relatedModels) &&
             (idOnly ||
-            this.model.hasDirtyRelation(key, relatedModels) ||
-            relatedModels.isDirty(nested))
+              this.model.hasDirtyRelation(key, relatedModels) ||
+              relatedModels.isDirty(nested))
           ) {
             data = this._processRelatedModel(relatedModels, nested, idOnly)
           }
@@ -191,12 +191,12 @@ export class WritePayload<T extends SpraypaintBase> {
     const wp = new WritePayload(model, nested, idOnly)
     const relatedJSON = wp.asJSON().data
 
-    if(!this._isNewAndMarkedForDestruction(model)) {
+    if (!this._isNewAndMarkedForDestruction(model)) {
       this._pushInclude(relatedJSON)
     }
 
     wp.included.forEach(incl => {
-      if(!this._isNewAndMarkedForDestruction(model)) {
+      if (!this._isNewAndMarkedForDestruction(model)) {
         this._pushInclude(incl)
       }
     })

--- a/test/integration/nested-persistence.test.ts
+++ b/test/integration/nested-persistence.test.ts
@@ -243,7 +243,7 @@ describe("nested persistence", () => {
     // todo test unique includes/circular relationshio
     it("sends the correct payload", async () => {
       await instance.save({ with: { books: "genre", specialBooks: {} } })
-      
+
       expect(payloads[0]).to.deep.equal(expectedCreatePayload)
     })
 
@@ -291,7 +291,9 @@ describe("nested persistence", () => {
 
       it("should not be sent in the payload", async () => {
         await instance.save({ with: { books: "genre" } })
-        expect((<any>payloads)[0].included.some((i: any) => i['types'] === 'genre')).to.be.false
+        expect(
+          (<any>payloads)[0].included.some((i: any) => i["types"] === "genre")
+        ).to.be.false
       })
     })
 


### PR DESCRIPTION
In extremely rare cases, companies will not allow the PATCH HTTP verb.
For a longer explanation of this issue, see https://github.com/equivalent/scrapbook2/blob/master/archive/blogs/2016-12-12-put-vs-patch-vs-your-firewal.md

The solution is to send a POST alongside the `X-HTTP-Method-Override`
header. When the server adds `Rack::MethodOverride`, the header will
take precedence (making the server think it's a PATCH).

You can enable this behavior by setting the `patchAsPost` flag:

```ts
class ApplicationRecord extends SpraypaintBase {
  // ... code ...
  static patchAsPost = true
}
```