### PR TITLE
Add credentials header into fetch request

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -727,6 +727,11 @@ export class SpraypaintBase {
    */
   static fetchOptions(): RequestInit {
     const options = {
+      credentials: "same-origin" as
+        | "same-origin"
+        | "omit"
+        | "include"
+        | undefined,
       headers: {
         Accept: "application/vnd.api+json",
         ["Content-Type"]: "application/vnd.api+json"

--- a/test/integration/fetch-middleware.test.ts
+++ b/test/integration/fetch-middleware.test.ts
@@ -167,6 +167,7 @@ describe("fetch middleware", () => {
         return Author.all().then(({ data }) => {
           expect(before.url).to.eq("http://example.com/api/v1/authors")
           expect(before.options).to.deep.eq({
+            credentials: "same-origin",
             headers: {
               Accept: "application/vnd.api+json",
               "Content-Type": "application/vnd.api+json",
@@ -341,6 +342,7 @@ describe("fetch middleware", () => {
         return author.save().then(() => {
           expect(before.url).to.eq("http://example.com/api/v1/authors")
           expect(before.options).to.deep.eq({
+            credentials: "same-origin",
             headers: {
               Accept: "application/vnd.api+json",
               "CUSTOM-HEADER": "whatever",


### PR DESCRIPTION
The default value for credentials is "same-origin", however this wasn't always the case.
Some older browsers implemented a version of the fetch specification where the default was "omit"
Because of this, those browsers omit the cookie when making requests, causing a 401 to be returned from the server

See https://github.com/github/fetch#sending-cookies