### PR TITLE
Encode param values when IE

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -1,3 +1,3 @@
 typescript:
-  versions: ">= 2.8.0"
+  versions: [">= 2.8.0", "< 3.5.0"]
   commands: yarn test

--- a/src/util/parameterize.ts
+++ b/src/util/parameterize.ts
@@ -3,7 +3,7 @@ const parameterize = (obj: any, prefix?: string): string => {
 
   for (let key in obj) {
     if (obj.hasOwnProperty(key)) {
-      const value = obj[key]
+      let value = obj[key]
 
       if (value !== undefined && value !== null && value !== "") {
         if (prefix) {
@@ -11,13 +11,16 @@ const parameterize = (obj: any, prefix?: string): string => {
         }
 
         if (Array.isArray(value)) {
+          value = value.map(v => {
+            return maybeEncode(v)
+          })
           if (value.length > 0) {
             str.push(`${key}=${value.join(",")}`)
           }
         } else if (typeof value === "object") {
           str.push(parameterize(value, key))
         } else {
-          str.push(`${key}=${value}`)
+          str.push(`${key}=${maybeEncode(value)}`)
         }
       }
     }
@@ -29,6 +32,15 @@ const parameterize = (obj: any, prefix?: string): string => {
   })
 
   return str.join("&")
+}
+
+// IE does not encode by default like other browsers
+const maybeEncode = (value: string): string => {
+  const isBrowser = typeof window !== "undefined"
+  const isIE = isBrowser && window.navigator.userAgent.match(/(MSIE|Trident)/)
+  const isEncoded = typeof value === "string" && value.indexOf("%") !== -1
+  const shouldEncode = isBrowser && isIE && !isEncoded
+  return shouldEncode ? encodeURIComponent(value) : value
 }
 
 export { parameterize as default }


### PR DESCRIPTION
IE does not automatically encode, so let's do it for our users
automatically. This also checks if the value is already encoded (naively
checking for "%") and avoids if so.