### PR TITLE
Add extraFetchOptions fluent API to allow for per-call fetchOptions

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -826,6 +826,13 @@ export class SpraypaintBase {
     return this.scope().extraParams(clause)
   }
 
+  static extraFetchOptions<I extends typeof SpraypaintBase>(
+    this: I,
+    options: RequestInit
+  ) {
+    return this.scope().extraFetchOptions(options)
+  }
+
   static order<I extends typeof SpraypaintBase>(
     this: I,
     clause: SortScope | string

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -51,6 +51,7 @@ export class Scope<T extends SpraypaintBase = SpraypaintBase> {
   private _include: IncludeScopeHash = {}
   private _stats: StatsScope = {}
   private _extraParams: any = {}
+  private _extraFetchOptions: RequestInit = {}
 
   constructor(model: Constructor<T> | typeof SpraypaintBase) {
     this.model = (model as any) as typeof SpraypaintBase
@@ -205,6 +206,18 @@ export class Scope<T extends SpraypaintBase = SpraypaintBase> {
     return copy
   }
 
+  extraFetchOptions(options: RequestInit): Scope<T> {
+    const copy = this.copy()
+
+    for (const key in options) {
+      if (options.hasOwnProperty(key)) {
+        copy._extraFetchOptions[key] = options[key]
+      }
+    }
+
+    return copy
+  }
+
   // The `Model` class has a `scope()` method to return the scope for it.
   // This method makes it possible for methods to expect either a model or
   // a scope and reliably cast them to a scope for use via `scope()`
@@ -237,6 +250,13 @@ export class Scope<T extends SpraypaintBase = SpraypaintBase> {
 
     if (paramString !== "") {
       return paramString
+    }
+  }
+
+  fetchOptions(): RequestInit {
+    return {
+      ...this.model.fetchOptions(),
+      ...this._extraFetchOptions
     }
   }
 
@@ -310,9 +330,7 @@ export class Scope<T extends SpraypaintBase = SpraypaintBase> {
       url = `${url}?${qp}`
     }
     const request = new Request(this.model.middlewareStack, this.model.logger)
-    const fetchOpts = this.model.fetchOptions()
-
-    const response = await request.get(url, fetchOpts)
+    const response = await request.get(url, this.fetchOptions())
     refreshJWT(this.model, response)
     return response.jsonPayload
   }

--- a/test/integration/finders.test.ts
+++ b/test/integration/finders.test.ts
@@ -20,6 +20,19 @@ describe("Model finders", () => {
       })
     })
 
+    it("allows for overridable fetch options", async () => {
+      const dummyHeaders = { Test: "hi" }
+      const { data } = await Person.extraFetchOptions({
+        headers: dummyHeaders
+      }).find(1)
+
+      const defaultFetchOptions = Person.fetchOptions
+
+      const lastOptions = fetchMock.lastOptions()
+
+      expect(lastOptions.headers).to.deep.eq(dummyHeaders)
+    })
+
     it("returns a promise that resolves the correct instance", async () => {
       const { data } = await Person.find(1)
       expect(data)


### PR DESCRIPTION
The impetus for this PR is to allow for use of [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) to abort the underlying `fetch` calls. They require passing in a `signal` to the `fetch` call directly.

An alternative approach could be to expose a `.signal()` or `.abortSignal()` scope call that would store the signal for later.