### PR TITLE
Fixes comparison in validation error

### DIFF
--- a/src/util/validation-error-builder.ts
+++ b/src/util/validation-error-builder.ts
@@ -68,7 +68,12 @@ export class ValidationErrorBuilder<T extends SpraypaintBase> {
     let relatedObject = model[model.klass.deserializeKey(meta.name)]
     if (Array.isArray(relatedObject)) {
       relatedObject = relatedObject.find(r => {
-        return r.id === meta.id || r.temp_id === meta["temp-id"]
+        // For now graphiti is returning the related object id as an integer
+        // where the related object's ID is a string
+        return (
+          String(r.id) === String(meta.id) ||
+          (r.temp_id && r.temp_id === meta["temp-id"])
+        )
       })
     }
 

--- a/src/util/validation-error-builder.ts
+++ b/src/util/validation-error-builder.ts
@@ -71,7 +71,7 @@ export class ValidationErrorBuilder<T extends SpraypaintBase> {
         // For now graphiti is returning the related object id as an integer
         // where the related object's ID is a string
         return (
-          String(r.id) === String(meta.id) ||
+          (r.id && String(r.id) === String(meta.id)) ||
           (r.temp_id && r.temp_id === meta["temp-id"])
         )
       })


### PR DESCRIPTION
The IDs need to be compared as strings, or graphiti_errors should be updated to compare as strings

Also ensures that a temp_id exists before comparing, avoiding comparing two undefined values