### PR TITLE
Make async/wait for middleware beforeFilters and afterFilters possible

### DIFF
--- a/src/middleware-stack.ts
+++ b/src/middleware-stack.ts
@@ -1,6 +1,12 @@
 export type BeforeFilter = (requestUrl: string, options: RequestInit) => void
 export type AfterFilter = (response: Response, json: JSON) => void
 
+async function asyncForEach(array: Array<Function>, callback: Function) {
+  for (let index = 0; index < array.length; index += 1) {
+    await callback(array[index], index, array)
+  }
+}
+
 export class MiddlewareStack {
   private _beforeFilters: BeforeFilter[] = []
   private _afterFilters: AfterFilter[] = []
@@ -18,15 +24,15 @@ export class MiddlewareStack {
     return this._afterFilters
   }
 
-  beforeFetch(requestUrl: string, options: RequestInit) {
-    this._beforeFilters.forEach(filter => {
-      filter(requestUrl, options)
+  async beforeFetch(requestUrl: string, options: RequestInit) {
+    await asyncForEach(this._beforeFilters, async (filter: Function) => {
+      await filter(requestUrl, options)
     })
   }
 
-  afterFetch(response: Response, json: JSON) {
-    this._afterFilters.forEach(filter => {
-      filter(response, json)
+  async afterFetch(response: Response, json: JSON) {
+    await asyncForEach(this._afterFilters, async (filter: Function) => {
+      await filter(response, json)
     })
   }
 }

--- a/src/request.ts
+++ b/src/request.ts
@@ -91,7 +91,7 @@ export class Request {
 
   private async _fetch(url: string, options: RequestInit): Promise<any> {
     try {
-      this.middleware.beforeFetch(url, options)
+      await this.middleware.beforeFetch(url, options)
     } catch (e) {
       throw new RequestError(
         "beforeFetch failed; review middleware.beforeFetch stack",


### PR DESCRIPTION
When information, required to make a new Fetch request, is retrieved with a Promise the value cannot be included in the filter.
With this commit both synchronous and asynchronous functions call be used to retrieve information.
This makes sense as Fetch is an asynchronous function as well.

Note: Credits to Sebastien Chopin (https://codeburst.io/javascript-async-await-with-foreach-b6ba62bbf404) for a part of this code snippet. 