### PR TITLE
Enable developers to read response.json() when ResponseError is being thrown

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -125,7 +125,7 @@ export class Request {
 
     let json
     try {
-      json = await response.json()
+      json = await response.clone().json()
     } catch (e) {
       if (response.status === 202) return
       throw new ResponseError(response, "invalid json", e)

--- a/test/integration/fetch-middleware.test.ts
+++ b/test/integration/fetch-middleware.test.ts
@@ -217,11 +217,13 @@ describe("fetch middleware", () => {
           .then(({ data }) => {
             expect("dont get here!").to.eq(true)
           })
-          .catch(e => {
+          .catch(async e => {
             expect(e.message).to.eq(
               "afterFetch failed; review middleware.afterFetch stack"
             )
             expect(e.response.status).to.eq(401)
+            // If fetch.clone method is not used, error for getting json is: body used already for: URL
+            expect(await e.response.json()).to.be.an("object")
             expect(e.originalError).to.eq(ABORT_ERR)
           })
       })
@@ -392,11 +394,13 @@ describe("fetch middleware", () => {
           .then(() => {
             expect("dont get here!").to.eq(true)
           })
-          .catch(e => {
+          .catch(async e => {
             expect(e.message).to.eq(
               "afterFetch failed; review middleware.afterFetch stack"
             )
             expect(e.response.status).to.eq(401)
+            // If fetch.clone method is not used, error for getting json is: body used already for: URL
+            expect(await e.response.json()).to.be.an("object")
             expect(e.originalError).to.eq(ABORT_ERR)
           })
       })


### PR DESCRIPTION
Because originally response.json() was being called before throwing a ResponseError, a developer cannot access the original body to examine for specific (json) errors for correct error handling.
Reason: response.json() can only be called once per instance.
Therefore, a good practise for libraries is to clone the response before reading it to resolve this issue

More about this issue: https://stackoverflow.com/questions/40497859/reread-a-response-body-from-javascripts-fetch
About the clone method: https://developer.mozilla.org/en-US/docs/Web/API/Response/clone