### PR TITLE
Hotfix for async middleware

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -132,7 +132,7 @@ export class Request {
     }
 
     try {
-      this.middleware.afterFetch(response, json)
+      await this.middleware.afterFetch(response, json)
     } catch (e) {
       // afterFetch middleware failed
       throw new ResponseError(


### PR DESCRIPTION
Because afterFetch is returning a promise, the try catch statement won't work without await

How to test:
 - Run tests, without this commit they will fail.

Sorry about that, I'm new to this framework. I didn't run the test suite with my previous MR :(