### PR TITLE
Adds a json property to ResponseError exceptions

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -143,7 +143,7 @@ export class Request {
     }
 
     if (response.status >= 500) {
-      throw new ResponseError(response, "Server Error")
+      throw new ResponseError(response, "Server Error", undefined, json)
       // Allow 422 since we specially handle validation errors
     } else if (response.status !== 422 && json.data === undefined) {
       if (response.status === 404) {
@@ -180,14 +180,17 @@ class RequestError extends Error {
 class ResponseError extends Error {
   response: Response | null
   originalError: Error | undefined
+  json: Object | undefined
 
   constructor(
     response: Response | null,
     message?: string,
-    originalError?: Error
+    originalError?: Error,
+    json?: Object
   ) {
     super(message || "Invalid Response")
     this.response = response
     this.originalError = originalError
+    this.json = json
   }
 }


### PR DESCRIPTION
I did not see a way to see the response of a `500` error since the response body stream was already processed in `request.ts`

This change adds a `json` property to the `ResponseError` exception so the JSON body can be accessed from a spraypaint client.