### PR TITLE
Fix/27/constructor vs direct relationship

### DIFF
--- a/src/util/write-payload.ts
+++ b/src/util/write-payload.ts
@@ -118,11 +118,13 @@ export class WritePayload<T extends SpraypaintBase> {
         } else {
           // Either the related model is dirty, or it's a dirty relation
           // (maybe the "department" is not dirty, but the employee changed departments
+          // or the model is new
           if (
             !this._isNewAndMarkedForDestruction(relatedModels) &&
             (idOnly ||
               this.model.hasDirtyRelation(key, relatedModels) ||
-              relatedModels.isDirty(nested))
+              relatedModels.isDirty(nested) ||
+              !this.model.isPersisted)
           ) {
             data = this._processRelatedModel(relatedModels, nested, idOnly)
           }

--- a/test/unit/write-payload.test.ts
+++ b/test/unit/write-payload.test.ts
@@ -1,6 +1,6 @@
 import { sinon, expect } from "../test-helper"
 import { WritePayload } from "../../src/util/write-payload"
-import { Person, PersonWithDasherizedKeys } from "../fixtures"
+import { Person, PersonWithDasherizedKeys, Author, Genre } from "../fixtures"
 
 describe("WritePayload", () => {
   it("Does not serialize number attributes as empty string", () => {
@@ -43,6 +43,34 @@ describe("WritePayload", () => {
           "first-name": "Joe"
         }
       }
+    })
+  })
+
+  it("sends persisted relationship defined via direct assignment", () => {
+    const genre = new Genre({ name: "Horror", id: "1" })
+    genre.isPersisted = true
+    const author = new Author()
+    author.genre = genre
+    const payload = new WritePayload(author, ["genre"])
+    expect(payload.asJSON()).to.deep.equal({
+      data: {
+        type: "authors",
+        relationships: {
+          genre: {
+            data: {
+              id: "1",
+              type: "genres",
+              method: "update"
+            }
+          }
+        }
+      },
+      included: [
+        {
+          id: "1",
+          type: "genres"
+        }
+      ]
     })
   })
 })

--- a/test/unit/write-payload.test.ts
+++ b/test/unit/write-payload.test.ts
@@ -46,7 +46,7 @@ describe("WritePayload", () => {
     })
   })
 
-  it("sends persisted relationship defined via direct assignment", () => {
+  it("sends persisted relationships defined via direct assignment", () => {
     const genre = new Genre({ name: "Horror", id: "1" })
     genre.isPersisted = true
     const author = new Author()
@@ -71,6 +71,45 @@ describe("WritePayload", () => {
           type: "genres"
         }
       ]
+    })
+  })
+
+  it("sends persisted relationships defined via constructor", () => {
+    const genre = new Genre({ name: "Horror", id: "1" })
+    genre.isPersisted = true
+    const author = new Author({ genre })
+    const payload = new WritePayload(author, ["genre"])
+    expect(payload.asJSON()).to.deep.equal({
+      data: {
+        type: "authors",
+        relationships: {
+          genre: {
+            data: {
+              id: "1",
+              type: "genres",
+              method: "update"
+            }
+          }
+        }
+      },
+      included: [
+        {
+          id: "1",
+          type: "genres"
+        }
+      ]
+    })
+  })
+
+  it("does not send persisted relationships defined via constructor if not included", () => {
+    const genre = new Genre({ name: "Horror", id: "1" })
+    genre.isPersisted = true
+    const author = new Author({ genre })
+    const payload = new WritePayload(author)
+    expect(payload.asJSON()).to.deep.equal({
+      data: {
+        type: "authors"
+      }
     })
   })
 })


### PR DESCRIPTION
This is a proposed fix of #27 

As far as I see, we want to *always* include the relationships when processing the payload of a non persisted instance.

I added tests for both the scenario that was working already in master

```js
var country = new Country({ id: '123', name: 'USA' });
country.isPersisted = true;

var company = new Company({ name: 'ACME' });
company.country = country;
company.save({ with: 'country' });
```

And for the one that was failing:

```js 
var company = new Company({ name: 'ACME', country: country });
company.save({ with: 'country' });
```

Plus an extra test case to check that the relationships are still not sent if not explicitly included.

```js
company.save();
```