### PR TITLE
Persisting new resources with already persisted plural relationship members fails

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -710,7 +710,7 @@ export class SpraypaintBase {
     relatedModel: SpraypaintBase
   ): boolean {
     const dc = new DirtyChecker(this)
-    return dc.checkRelation(relationName, relatedModel)
+    return !this.isPersisted || dc.checkRelation(relationName, relatedModel)
   }
 
   dup(): this {

--- a/src/util/write-payload.ts
+++ b/src/util/write-payload.ts
@@ -106,7 +106,6 @@ export class WritePayload<T extends SpraypaintBase> {
             if (
               !this._isNewAndMarkedForDestruction(relatedModel) &&
               (idOnly ||
-                !this.model.isPersisted ||
                 this.model.hasDirtyRelation(key, relatedModel) ||
                 relatedModel.isDirty(nested))
             ) {
@@ -123,7 +122,6 @@ export class WritePayload<T extends SpraypaintBase> {
           if (
             !this._isNewAndMarkedForDestruction(relatedModels) &&
             (idOnly ||
-              !this.model.isPersisted ||
               this.model.hasDirtyRelation(key, relatedModels) ||
               relatedModels.isDirty(nested))
           ) {

--- a/src/util/write-payload.ts
+++ b/src/util/write-payload.ts
@@ -106,6 +106,7 @@ export class WritePayload<T extends SpraypaintBase> {
             if (
               !this._isNewAndMarkedForDestruction(relatedModel) &&
               (idOnly ||
+                !this.model.isPersisted ||
                 this.model.hasDirtyRelation(key, relatedModel) ||
                 relatedModel.isDirty(nested))
             ) {
@@ -122,9 +123,9 @@ export class WritePayload<T extends SpraypaintBase> {
           if (
             !this._isNewAndMarkedForDestruction(relatedModels) &&
             (idOnly ||
+              !this.model.isPersisted ||
               this.model.hasDirtyRelation(key, relatedModels) ||
-              relatedModels.isDirty(nested) ||
-              !this.model.isPersisted)
+              relatedModels.isDirty(nested))
           ) {
             data = this._processRelatedModel(relatedModels, nested, idOnly)
           }

--- a/test/integration/nested-persistence.test.ts
+++ b/test/integration/nested-persistence.test.ts
@@ -273,17 +273,6 @@ describe("nested persistence", () => {
       expect(instance.books[0].genre.name).to.eq("name from server")
     })
 
-    describe("when a hasMany relationship has no dirty members", () => {
-      beforeEach(() => {
-        instance.books[0] = new Book()
-      })
-
-      it("should not be sent in the payload", async () => {
-        await instance.save({ with: { books: "genre" } })
-        expect((<any>payloads)[0].data.relationships).to.eq(undefined)
-      })
-    })
-
     describe("when a belongsTo relationship has unpersisted members that are marked for destruction", () => {
       beforeEach(() => {
         instance.books[0].genre.isMarkedForDestruction = true


### PR DESCRIPTION
@nobitagit did a great job on https://github.com/graphiti-api/spraypaint.js/pull/47 fixing persistence of already persisted objects via a singular relationship (has one), however the situation still exists on plural relationships (has many).