### PR TITLE
fix - ensure all tests are running on ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:watch": "yarn run test --watch",
     "test:all-versions": "yarn tav",
     "test:es6-compatibility": "yarn build:es6 && mocha --opts test/es6-compatibility/mocha.opts",
-    "test:ci": "yarn test:all-versions && yarn test:es6-compatibility",
+    "test:ci": "yarn test:all-versions && yarn test:es6-compatibility && yarn test",
     "lint": "yarn run lint:ci --fix",
     "lint:ci": "yarn run eslint {src,test}{,/**}/*.ts",
     "release": "script/release",


### PR DESCRIPTION
When https://github.com/graphiti-api/spraypaint.js/pull/50 was opened I noticed Travis is running an incomplete test suite. See [my comment here](https://github.com/graphiti-api/spraypaint.js/pull/50#issuecomment-553643079).
This PR makes sure all tests are run on the ci.

To confirm, compare this [log from a recent PR](https://travis-ci.org/graphiti-api/spraypaint.js/jobs/613578296?utm_medium=notification&utm_source=github_status) with the one [generated for this PR](https://travis-ci.org/graphiti-api/spraypaint.js/jobs/621327901?utm_medium=notification&utm_source=github_status). 
