### PR TITLE
Expose resource level metadata

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -654,6 +654,10 @@ export class SpraypaintBase {
     this.__meta__ = metaObj
   }
 
+  get meta(): object {
+    return this.__meta__ || {}
+  }
+
   relationshipResourceIdentifiers(relationNames: string[]) {
     return relationshipIdentifiersFor(this, relationNames)
   }

--- a/src/model.ts
+++ b/src/model.ts
@@ -422,6 +422,7 @@ export class SpraypaintBase {
   @nonenumerable private _links!: ModelRecord<this>
   @nonenumerable private _originalLinks!: ModelRecord<this>
   @nonenumerable private __meta__: any
+  @nonenumerable private _metaDirty: boolean = false
   @nonenumerable private _errors: ValidationErrors<this> = {}
 
   constructor(attrs?: Record<string, any>) {
@@ -650,12 +651,19 @@ export class SpraypaintBase {
     }
   }
 
-  setMeta(metaObj: object | undefined) {
+  setMeta(metaObj: object | undefined, markDirty = true) {
     this.__meta__ = metaObj
+    if (markDirty) {
+      this._metaDirty = true
+    }
   }
 
   get meta(): object {
     return this.__meta__ || {}
+  }
+
+  get isMetaDirty(): boolean {
+    return this._metaDirty
   }
 
   relationshipResourceIdentifiers(relationNames: string[]) {

--- a/src/util/deserialize.ts
+++ b/src/util/deserialize.ts
@@ -134,7 +134,7 @@ class Deserializer {
     instance.assignLinks(datum.links)
 
     // assign meta
-    instance.setMeta(datum.meta)
+    instance.setMeta(datum.meta, false)
 
     // so we don't double-process the same thing
     // must push before relationships

--- a/src/util/write-payload.ts
+++ b/src/util/write-payload.ts
@@ -170,7 +170,7 @@ export class WritePayload<T extends SpraypaintBase> {
     }
 
     const _meta: object = this.model.meta
-    if (Object.keys(_meta).length > 0) {
+    if (this.model.isMetaDirty && Object.keys(_meta).length > 0) {
       data.meta = _meta
     }
 

--- a/src/util/write-payload.ts
+++ b/src/util/write-payload.ts
@@ -169,6 +169,11 @@ export class WritePayload<T extends SpraypaintBase> {
       json.included = this.included
     }
 
+    const _meta: object = this.model.meta
+    if (Object.keys(_meta).length > 0) {
+      data.meta = _meta
+    }
+
     return json
   }
 

--- a/test/unit/model.test.ts
+++ b/test/unit/model.test.ts
@@ -763,7 +763,7 @@ describe("Model", () => {
 
     it("assigns metadata correctly", () => {
       const instance = ApplicationRecord.fromJsonapi(doc.data, doc)
-      expect(instance.__meta__).to.eql({
+      expect(instance.meta).to.eql({
         big: true
       })
     })
@@ -1567,6 +1567,9 @@ describe("Model", () => {
           links: {
             self: { href: "/api/person/1", meta: { count: 10 } },
             web_view: "/person/1"
+          },
+          meta: {
+            editable: true
           }
         }
       }
@@ -1577,7 +1580,7 @@ describe("Model", () => {
           meta: { count: 10 }
         })
         expect(person.links.webView).to.eq("/person/1")
-        expect(person.links.comments).to
+        expect(person.meta).to.deep.equal({ editable: true })
       }
 
       it("from instance", () => {

--- a/test/unit/write-payload.test.ts
+++ b/test/unit/write-payload.test.ts
@@ -53,7 +53,7 @@ describe("WritePayload", () => {
   })
 
   describe("metadata", () => {
-    it("sends metadata", () => {
+    it("sends metadata if modified by the user", () => {
       let person = new Person({ first_name: "Joe", age: 23 })
       person.setMeta({ mock: "metadata" })
       let payload = new WritePayload(person)
@@ -66,6 +66,21 @@ describe("WritePayload", () => {
           },
           meta: {
             mock: "metadata"
+          }
+        }
+      })
+    })
+
+    it("does not send unmodified metadata", () => {
+      let person = new Person({ first_name: "Joe", age: 23 })
+      person.setMeta({ mock: "metadata" }, false)
+      let payload = new WritePayload(person)
+      expect(payload.asJSON()).to.deep.equal({
+        data: {
+          type: "people",
+          attributes: {
+            age: 23,
+            first_name: "Joe"
           }
         }
       })

--- a/test/unit/write-payload.test.ts
+++ b/test/unit/write-payload.test.ts
@@ -1,6 +1,12 @@
 import { sinon, expect } from "../test-helper"
 import { WritePayload } from "../../src/util/write-payload"
-import { Person, PersonWithDasherizedKeys, Author, Genre, Book } from "../fixtures"
+import {
+  Person,
+  PersonWithDasherizedKeys,
+  Author,
+  Genre,
+  Book
+} from "../fixtures"
 
 describe("WritePayload", () => {
   it("Does not serialize number attributes as empty string", () => {
@@ -43,6 +49,26 @@ describe("WritePayload", () => {
           "first-name": "Joe"
         }
       }
+    })
+  })
+
+  describe("metadata", () => {
+    it("sends metadata", () => {
+      let person = new Person({ first_name: "Joe", age: 23 })
+      person.setMeta({ mock: "metadata" })
+      let payload = new WritePayload(person)
+      expect(payload.asJSON()).to.deep.equal({
+        data: {
+          type: "people",
+          attributes: {
+            age: 23,
+            first_name: "Joe"
+          },
+          meta: {
+            mock: "metadata"
+          }
+        }
+      })
     })
   })
 


### PR DESCRIPTION
JSON:API supports metadata at the individual resource level:

```json
{
  "id": "1",
  "type": "people",
  "attributes": { "firstName": "Donald Budge" },
  "meta": {
    "editable": true
  }
}
```

Spraypaint currently parses the JSON and stores the metadata in a private `__meta__` variable, but then does nothing with it.

This PR adds a getter that allows the metadata to be accessed by users:

```js
const { data } = await Person.find('1');
const editable = data.meta.editable;
...
```

This PR also allows the resource level metadata to be sent to the server during writes. This is useful when extra information is needed to be sent along with a resource where the extra data does not make sense as an `attribute`.