### PR TITLE
Add support for keyCasing for server calls

### DIFF
--- a/src/scope.ts
+++ b/src/scope.ts
@@ -85,7 +85,8 @@ export class Scope<T extends SpraypaintBase = SpraypaintBase> {
     const copy = this.copy()
 
     Object.keys(obj).forEach(k => {
-      copy._associations[k] = (obj as any)[k]
+      const serverCasedKey = this.model.serializeKey(k)
+      copy._associations[serverCasedKey] = (obj as any)[k]
     })
 
     return copy

--- a/test/unit/scope.test.ts
+++ b/test/unit/scope.test.ts
@@ -253,6 +253,34 @@ describe("Scope", () => {
     })
   })
 
+  describe("#merge()", () => {
+    it("updates the scope", () => {
+      scope = scope
+        .includes(["foo_bar"])
+        .merge({ foo_bar: scope.where({ foo: "bar" }) })
+      const qp = scope.asQueryParams()
+
+      expect(qp.filter).to.eql({
+        foo_bar: {
+          foo: "bar"
+        }
+      })
+    })
+
+    it("respects the server keycase configuration", () => {
+      scope = scope
+        .includes(["foo_bar_baz"])
+        .merge({ fooBarBaz: scope.where({ foo: "bar" }) })
+      const qp = scope.asQueryParams()
+
+      expect(qp.filter).to.eql({
+        foo_bar_baz: {
+          foo: "bar"
+        }
+      })
+    })
+  })
+
   describe("#scope()", () => {
     it("returns itself", () => {
       expect(scope.scope()).to.equal(scope)

--- a/test/unit/scope.test.ts
+++ b/test/unit/scope.test.ts
@@ -8,6 +8,8 @@ let scope: Scope<Author>
 beforeEach(() => {
   const model = sinon.stub() as any
   model.jsonapiType = "people"
+  model.serializeKey = SpraypaintBase.serializeKey
+  model.keyCase = { server: "snake", client: "camel" }
   scope = new Scope(model)
 })
 
@@ -55,6 +57,14 @@ describe("Scope", () => {
       expect(newScope).to.be.instanceof(Scope)
       expect(newScope).not.to.equal(scope)
     })
+
+    it("respects the server keycase configuration", () => {
+      scope = scope.where({ fooBar: "baz" }).where({ fooBarBaz: "fooBar" })
+      expect((scope as any)._filter).to.eql({
+        foo_bar: "baz",
+        foo_bar_baz: "fooBar"
+      })
+    })
   })
 
   describe("#stats()", () => {
@@ -72,6 +82,13 @@ describe("Scope", () => {
       expect(newScope).to.be.instanceof(Scope)
       expect(newScope).not.to.equal(scope)
     })
+
+    it("respects the server keycase configuration", () => {
+      scope = scope.stats({ someThing: "someOtherThing" })
+      expect((scope as any)._stats).to.eql({
+        some_thing: "some_other_thing"
+      })
+    })
   })
 
   describe("#order()", () => {
@@ -87,6 +104,14 @@ describe("Scope", () => {
       const newScope = scope.order("foo")
       expect(newScope).to.be.instanceof(Scope)
       expect(newScope).not.to.equal(scope)
+    })
+
+    it("respects the server keycase configuration", () => {
+      scope = scope.order("fooBar").order({ fooBarBaz: "desc" })
+      expect((scope as any)._sort).to.eql({
+        foo_bar: "asc",
+        foo_bar_baz: "desc"
+      })
     })
   })
 
@@ -105,6 +130,13 @@ describe("Scope", () => {
       const newScope = scope.select({ people: ["foo"] })
       expect(newScope).to.be.instanceof(Scope)
       expect(newScope).not.to.equal(scope)
+    })
+
+    it("respects the server keycase configuration", () => {
+      scope = scope.select({ someThing: ["firstThing", "secondThing"] })
+      expect((scope as any)._fields).to.eql({
+        some_thing: ["first_thing", "second_thing"]
+      })
     })
 
     describe("when passed an array of strings", () => {
@@ -134,6 +166,13 @@ describe("Scope", () => {
       expect(newScope).not.to.equal(scope)
     })
 
+    it("respects the server keycase configuration", () => {
+      scope = scope.selectExtra({ someThing: ["firstThing", "secondThing"] })
+      expect((scope as any)._extra_fields).to.eql({
+        some_thing: ["first_thing", "second_thing"]
+      })
+    })
+
     describe("when passed an array of strings", () => {
       it("infers the jsonapi type", () => {
         const newScope = scope.selectExtra(["foo"])
@@ -152,6 +191,13 @@ describe("Scope", () => {
           foo: {}
         })
       })
+
+      it("respects the server keycase configuration", () => {
+        scope = scope.includes("fooBar")
+        expect((scope as any)._include).to.eql({
+          foo_bar: {}
+        })
+      })
     })
 
     describe("when passed an array", () => {
@@ -160,6 +206,14 @@ describe("Scope", () => {
         expect((scope as any)._include).to.eql({
           foo: {},
           bar: {}
+        })
+      })
+
+      it("respects the server keycase configuration", () => {
+        scope = scope.includes(["fooBar", "fooBarBaz"])
+        expect((scope as any)._include).to.eql({
+          foo_bar: {},
+          foo_bar_baz: {}
         })
       })
     })
@@ -172,6 +226,20 @@ describe("Scope", () => {
             b: {},
             c: {
               d: {}
+            }
+          }
+        })
+      })
+
+      it("respects the server keycase configuration", () => {
+        scope = scope.includes({
+          fooBar: ["fooBarBaz", { fizzBuzz: "fizzBuzzBar" }]
+        })
+        expect((scope as any)._include).to.eql({
+          foo_bar: {
+            foo_bar_baz: {},
+            fizz_buzz: {
+              fizz_buzz_bar: {}
             }
           }
         })
@@ -239,14 +307,14 @@ describe("Scope", () => {
       scope = scope
         .page(2)
         .per(10)
-        .where({ foo: "bar" })
+        .where({ fooBar: "baz" })
         .order("foo")
         .order({ bar: "desc" })
         .select({ people: ["name", "age"] })
         .stats({ total: "count" })
         .includes({ a: ["b", { c: "d" }] })
       expect(scope.toQueryParams()).to.eq(
-        "page[number]=2&page[size]=10&filter[foo]=bar&sort=foo,-bar&fields[people]=name,age&stats[total]=count&include=a.b,a.c.d"
+        "page[number]=2&page[size]=10&filter[foo_bar]=baz&sort=foo,-bar&fields[people]=name,age&stats[total]=count&include=a.b,a.c.d"
       )
     })
 


### PR DESCRIPTION
This branch aims to close #29 by adding support for respecting the `keyCase` configuration when making calls to the server.

To my knowledge, this is only lacking support for `merge`, which should be trivial. Will add once I dig a bit further into the ramifications of changing object keys in `this._associations`. I also noticed the `extraParams` scope method, which I couldn't find in the documentation. I haven't added support for that because I'm not sure what it does.