### PR TITLE
fix hasError returning false when one validation error exists

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -688,7 +688,7 @@ export class SpraypaintBase {
   }
 
   get hasError() {
-    return Object.keys(this._errors).length > 1
+    return !!Object.keys(this._errors).length
   }
 
   clearErrors() {

--- a/test/unit/model.test.ts
+++ b/test/unit/model.test.ts
@@ -876,6 +876,16 @@ describe("Model", () => {
     })
   })
 
+  describe("hasError", () => {
+    it("returns boolean indicating whether there are errors", () => {
+      const instance = new Author()
+      let errors = { firstName: { title: "asdf" } } as any
+      expect(instance.hasError).to.eq(false)
+      instance.errors = errors
+      expect(instance.hasError).to.eq(true)
+    })
+  })
+
   describe("isDirty", () => {
     describe("when an attribute changes", () => {
       it("is marked as dirty", () => {


### PR DESCRIPTION
Fixes https://github.com/graphiti-api/spraypaint.js/issues/66