### PR TITLE
Upgrade TypeScript to 3.9.7

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
     "eslint:recommended",
     "plugin:prettier/recommended"
   ],
-  plugins: ["typescript"],
+  plugins: ["@typescript-eslint"],
   rules: {
     "no-undef": "off",
     "no-unused-vars": "off",
@@ -23,5 +23,5 @@ module.exports = {
     ecmaVersion: 6,
     sourceType: 'module'
   },
-  parser: "typescript-eslint-parser"
+  parser: "@typescript-eslint/parser"
 }

--- a/package.json
+++ b/package.json
@@ -77,13 +77,14 @@
     "@types/sinon": "^4.1.2",
     "@types/sinon-chai": "^2.7.29",
     "@types/winston": "2.3.7",
+    "@typescript-eslint/eslint-plugin": "^3.7.0",
+    "@typescript-eslint/parser": "^3.7.0",
     "chai": "^4.1.2",
     "chai-things": "^0.2.0",
     "es6-promise": "4.2.4",
-    "eslint": "5.12.0",
-    "eslint-config-prettier": "3.5.0",
-    "eslint-plugin-prettier": "3.0.1",
-    "eslint-plugin-typescript": "0.14.0",
+    "eslint": "5.16.0",
+    "eslint-config-prettier": "6.11.0",
+    "eslint-plugin-prettier": "3.1.4",
     "fetch-mock": "^5.10.0",
     "husky": "1.3.1",
     "isomorphic-fetch": "^2.2.1",
@@ -102,8 +103,7 @@
     "sinon-chai": "2.14.0",
     "test-all-versions": "3.3.3",
     "ts-node": "4.0.1",
-    "typescript": "3.2.4",
-    "typescript-eslint-parser": "21.0.2",
+    "typescript": "3.9.7",
     "winston": "^2.3.1"
   }
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -32,7 +32,6 @@ import { JsonapiTypeRegistry } from "./jsonapi-type-registry"
 import { camelize, underscore, dasherize } from "inflected"
 import { ILogger, logger as defaultLogger } from "./logger"
 import { MiddlewareStack, BeforeFilter, AfterFilter } from "./middleware-stack"
-import { Omit } from "./util/omit"
 import { EventBus } from "./event-bus"
 
 import {
@@ -123,8 +122,6 @@ export const applyModelConfig = <T extends typeof SpraypaintBase>(
   ModelClass: T,
   config: ModelConfigurationOptions
 ): void => {
-  let k: keyof ModelConfigurationOptions
-
   config = { ...config } // clone since we're going to mutate it
 
   // Handle all JWT configuration at once since it's run-order dependent
@@ -145,7 +142,7 @@ export const applyModelConfig = <T extends typeof SpraypaintBase>(
     delete config.jwt
   }
 
-  for (k in config) {
+  for (const k in config) {
     if (config.hasOwnProperty(k)) {
       ModelClass[k] = config[k]
     }
@@ -475,7 +472,10 @@ export class SpraypaintBase {
       )
 
       if (descriptor) {
-        Object.defineProperty(this, property, descriptor)
+        Object.defineProperty(this, property, {
+          ...descriptor,
+          enumerable: true
+        })
       }
     })
   }

--- a/src/util/omit.ts
+++ b/src/util/omit.ts
@@ -1,6 +1,0 @@
-// export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
-export type Diff<T extends string, U extends string> = ({ [P in T]: P } &
-  { [P in U]: never } & { [x: string]: never })[T]
-export type Omit<T, K> = {
-  [P in Diff<Extract<keyof T, string>, Extract<keyof K, string>>]: T[P]
-}

--- a/src/util/validation-error-builder.ts
+++ b/src/util/validation-error-builder.ts
@@ -4,7 +4,7 @@ import {
   JsonapiError,
   JsonapiErrorMeta
 } from "../jsonapi-spec"
-import { ValidationErrors, ValidationError } from "../validation-errors"
+import { ValidationErrors } from "../validation-errors"
 
 export class ValidationErrorBuilder<T extends SpraypaintBase> {
   static apply<T extends SpraypaintBase>(

--- a/src/validation-errors.ts
+++ b/src/validation-errors.ts
@@ -1,5 +1,4 @@
-import { Omit } from "./util/omit"
-import { SpraypaintBase, ModelRecord } from "./model"
+import { SpraypaintBase } from "./model"
 
 export interface IValidationError<T extends SpraypaintBase> {
   code: string
@@ -20,9 +19,7 @@ export class ValidationError<T extends SpraypaintBase>
   rawPayload!: Record<string, any>
 
   constructor(options: IValidationError<T>) {
-    let key: keyof IValidationError<T>
-
-    for (key in options) {
+    for (const key in options) {
       this[key] = options[key]
     }
   }
@@ -36,13 +33,4 @@ export type ErrorAttrs<T extends SpraypaintBase, K extends keyof T> = {
   [P in K]?: IValidationError<T> | undefined
 } & {
   base?: IValidationError<T>
-  /*
-   * Index is necessary for typescript 2.8 compatibility. If we don't have
-   * this, the `@Model()` decorator doesn't work.  The error is that subclasses
-   * of SpraypaintBase with additional fields aren't compatible since their error
-   * objects aren't compatible. This is because ErrorAttrs<SpraypaintBase> doesn't
-   * have a key like e.g. "title", whereas ErrorAttrs<Post> will. Adding an
-   * index allowing undefined values will make these compatible.
-   */
-  [key: string]: IValidationError<T> | undefined
 }

--- a/test/unit/write-payload.test.ts
+++ b/test/unit/write-payload.test.ts
@@ -1,6 +1,12 @@
-import { sinon, expect } from "../test-helper"
+import { expect } from "../test-helper"
 import { WritePayload } from "../../src/util/write-payload"
-import { Person, PersonWithDasherizedKeys, Author, Genre, Book } from "../fixtures"
+import {
+  Person,
+  PersonWithDasherizedKeys,
+  Author,
+  Genre,
+  Book
+} from "../fixtures"
 
 describe("WritePayload", () => {
   it("Does not serialize number attributes as empty string", () => {


### PR DESCRIPTION
### Changes

- Upgrade to `typescript@3.9.7`.
- Upgrade ESLint and TS-related packages to support upgraded TS package.
- Drop `Omit` module in favor of [native utility type](http://www.typescriptlang.org/docs/handbook/utility-types.html#omittk).
- Drop TS 2.8 compatibility index signature.
- Clean up unused imports.

Fixes https://github.com/graphiti-api/spraypaint.js/issues/49