### PR TITLE
Add dirtyChecker to Attributes definitions

### DIFF
--- a/src/attribute.ts
+++ b/src/attribute.ts
@@ -4,10 +4,13 @@ export type Attr<T> = (() => T) | { new (...args: any[]): T & object }
 
 export type AttrType<T> = Attr<T>
 
+export type DirtyChecker<T> = (prior: T, current: T) => boolean
+
 export interface AttrRecord<T> {
   name?: string
   type?: AttrType<T>
   persist?: boolean
+  dirtyChecker?: DirtyChecker<T>
 }
 
 export const attr = <T = any>(options?: AttrRecord<T>): Attribute<T> => {
@@ -26,13 +29,17 @@ export type AttributeOptions = Partial<{
   name: string
   type: () => any
   persist: boolean
+  dirtyChecker?: DirtyChecker<any>
 }>
+
+export const STRICT_EQUALITY_DIRTY_CHECKER: DirtyChecker<any> = (prior, current) => (prior !== current)
 
 export class Attribute<T = any> {
   isRelationship = false
   name!: string
   type?: T = undefined
   persist: boolean = true
+  dirtyChecker: DirtyChecker<T> = STRICT_EQUALITY_DIRTY_CHECKER
   owner!: typeof SpraypaintBase
 
   constructor(options: AttrRecord<T>) {
@@ -50,6 +57,10 @@ export class Attribute<T = any> {
 
     if (options.persist !== undefined) {
       this.persist = !!options.persist
+    }
+
+    if (options.dirtyChecker) {
+      this.dirtyChecker = (options.dirtyChecker)
     }
   }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -510,7 +510,8 @@ export class SpraypaintBase {
       Object.keys(attrs).forEach(k => {
         let self = this as any
         let changes = this.changes() as any
-        if (self[k] !== attrs[k] && !changes[k]) {
+        let attrDef = this.klass.attributeList[k]
+        if (attrDef.dirtyChecker(self[k], attrs[k]) && !changes[k]) {
           diff[k] = [self[k], attrs[k]]
           self[k] = attrs[k]
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -7,7 +7,8 @@ import {
   hasOne
 } from "../src/index"
 
-import { Attr, BelongsTo, HasMany, HasOne, Link } from "../src/decorators"
+import {Attr, BelongsTo, HasMany, HasOne, Link} from "../src/decorators"
+import {DirtyChecker} from "../src/attribute";
 
 @Model({
   baseUrl: "http://example.com",
@@ -40,11 +41,21 @@ export class PersonWithLinks extends Person {
   @Link() webView!: string
 }
 
+export interface Coordinates{
+  lon: number;
+  lat: number;
+}
+
+const dirtyCoordinatesChecker : DirtyChecker<Coordinates> = (prior: Coordinates, current: Coordinates) => (
+  (prior.lon !== current.lon) || (prior.lat !== current.lat)
+)
+
 @Model()
 export class PersonDetail extends ApplicationRecord {
   static jsonapiType = "person_details"
 
   @Attr address!: string
+  @Attr({dirtyChecker: dirtyCoordinatesChecker}) coordinates!: Coordinates | null
 }
 
 @Model({ keyCase: { server: "snake", client: "snake" } })

--- a/test/unit/attributes.test.ts
+++ b/test/unit/attributes.test.ts
@@ -1,5 +1,5 @@
 import { expect, sinon } from "../test-helper"
-import { attr, Attribute } from "../../src/attribute"
+import { attr, Attribute, STRICT_EQUALITY_DIRTY_CHECKER } from "../../src/attribute"
 
 describe("Attributes", () => {
   describe("Initializing Attribute", () => {
@@ -32,6 +32,17 @@ describe("Attributes", () => {
     it("allows persistence to be overridden", () => {
       const defaultAttr = attr({ persist: false })
       expect(defaultAttr.persist).to.be.false
+    })
+
+    it( "defaults to strict equality", () => {
+      const defaultAttr = attr()
+      expect(defaultAttr.dirtyChecker).to.eq(STRICT_EQUALITY_DIRTY_CHECKER)
+    })
+
+    it( "allows dirty checker function to be overridden", () => {
+      const customChecker = (prior:any, current:any) => (prior != current)
+      const defaultAttr = attr({dirtyChecker: customChecker})
+      expect(defaultAttr.dirtyChecker).to.eq(customChecker)
     })
   })
 })


### PR DESCRIPTION
I had the same problem as issue #56 when checking dirty attributes. Default dirty checking does use JS strict equality and result in non-primitive types attributes being marked as dirty.

Since there is no "right answer" for this problem, I suggest allowing developers to override the way dirty attributes are detected.

Here is an example :
```ts
// My non-primitive type
export interface Coordinates{
  lon: number;
  lat: number;
}

// A custom dirty checker. I may also compare using `JSON.stringify()`
const dirtyCoordinatesChecker : DirtyChecker<Coordinates> = (prior: Coordinates, current: Coordinates) => (
  (prior.lon !== current.lon) || (prior.lat !== current.lat)
)

@Model()
export class Place extends ApplicationRecord {
  static jsonapiType = "place"

  @Attr address!: string
  
  // Register my custom type and dirtyChecker
  @Attr({type: Coordinates, dirtyChecker: dirtyCoordinatesChecker}) coordinates!: Coordinates
}
```

I also changed the way `DirtyChecker._hasDirtyAttributes` is implemented, as current implementation allows some weird case where the instance is not marked as dirty but list some changes.
```ts
// current behaviour
let instance = net Place({coordinates: {lon: 3, lat: 48})
instance.coordinates = {lon: 3, lat: 48}

instance.isDirty() // false
instance.changes() // {coordinates:[{lon: 3, lat: 48},{lon: 3, lat: 48}]}

// new behaviour with above config
let instance = net Place({coordinates: {lon: 3, lat: 48})
instance.coordinates = {lon: 3, lat: 48}

instance.isDirty() // false
instance.changes() // {}
```

I can also write associated documentation but I did not find it in the project