### PR TITLE
Fix umd build by providing an isempty shim

### DIFF
--- a/esm-shims/isempty.js
+++ b/esm-shims/isempty.js
@@ -1,0 +1,1 @@
+export { default as isEmpty } from "lodash-es/isEmpty"

--- a/src/util/dirty-check.ts
+++ b/src/util/dirty-check.ts
@@ -2,7 +2,7 @@ import { SpraypaintBase, ModelRecord, ModelAttributeChangeSet } from "../model"
 import { IncludeDirective, IncludeScopeHash } from "./include-directive"
 import { IncludeScope } from "../scope"
 import { JsonapiResourceIdentifier } from "../jsonapi-spec"
-import {isEmpty} from "lodash";
+import { isEmpty } from "./isempty"
 
 class DirtyChecker<T extends SpraypaintBase> {
   model: T

--- a/src/util/isempty.ts
+++ b/src/util/isempty.ts
@@ -1,0 +1,1 @@
+export { isEmpty } from "lodash"


### PR DESCRIPTION
The umd build is currently broken - https://travis-ci.org/github/graphiti-api/spraypaint.js/jobs/714764931

This should fix that.

Please see discussion around this issue:
https://graphiti-api.slack.com/archives/CTGRQALH0/p1597865269139100
https://graphiti-api.slack.com/archives/CTGRQALH0/p1597867117147600
