### PR TITLE
declare type definitions on EventBus

### DIFF
--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -10,6 +10,8 @@ export interface IEventBus {
   dispatch: IDispatch
 }
 
-import * as EventBusAny from "eventbusjs"
-const EventBus: IEventBus = EventBusAny
+import * as EventBus from "eventbusjs"
+declare module "eventbusjs" {
+  interface EventBus extends IEventBus {}
+}
 export { EventBus }


### PR DESCRIPTION
To address https://github.com/graphiti-api/spraypaint.js/issues/54, adjusts the EventBus import to preserve the imported name, while still adding type definitions to the imported object.

I _think_ the behavior described in #54 has to do with some sort of proxying Rollup/tsc is doing; reassigning the name of the imported object seems to break accessing the properties of said object.  By maintaining the `EventBus` name across the import/export, the referenced bug no longer occurs. 

I'm by no means a TS expert, so this may be completely off base, but it does allow us to use `ApplicationRecord.sync = true` in my current project.