### PR TITLE
Fix React Native issue

### DIFF
--- a/src/util/parameterize.ts
+++ b/src/util/parameterize.ts
@@ -36,7 +36,7 @@ const parameterize = (obj: any, prefix?: string): string => {
 
 // IE does not encode by default like other browsers
 const maybeEncode = (value: string): string => {
-  const isBrowser = typeof window !== "undefined"
+  const isBrowser = typeof document !== "undefined"
   const isIE = isBrowser && window.navigator.userAgent.match(/(MSIE|Trident)/)
   const isEncoded = typeof value === "string" && value.indexOf("%") !== -1
   const shouldEncode = isBrowser && isIE && !isEncoded


### PR DESCRIPTION
window is an object in React Native, so in maybeEncode in parameterize.ts the isBrowser flag is set to true.
This then causes a crash as it attempts to check if window.navigator.userAgent.match(/(MSIE|Trident)/) , which throws an error as window.navigator is not defined.

Changing to checking for the presence of document should satisfy the condition of making sure its a browser, while evaluating to false in nodejs and react-native.