### PR TITLE
Allow configuration of credentials header

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -168,6 +168,7 @@ export class SpraypaintBase {
   static strictAttributes: boolean = false
   static logger: ILogger = defaultLogger
   static sync: boolean = false
+  static credentials: "same-origin" | "omit" | "include" | undefined
   static clientApplication: string | null = null
   static patchAsPost: boolean = false
 
@@ -754,6 +755,10 @@ export class SpraypaintBase {
         Accept: "application/vnd.api+json",
         ["Content-Type"]: "application/vnd.api+json"
       } as any
+    }
+
+    if (this.credentials) {
+      options.credentials = this.credentials
     }
 
     if (this.clientApplication) {

--- a/test/unit/model.test.ts
+++ b/test/unit/model.test.ts
@@ -1493,6 +1493,26 @@ describe("Model", () => {
   })
 
   describe("#fetchOptions", () => {
+    context("credentials is set", () => {
+      beforeEach(() => {
+        Author.credentials = "include"
+      })
+
+      afterEach(() => {
+        Author.credentials = "same-origin"
+      })
+
+      it("sets the credentials header", () => {
+        expect(<any>Author.fetchOptions().credentials).to.eq("include")
+      })
+    })
+
+    context("credentials is NOT set", () => {
+      it("sets the credentials header", () => {
+        expect(<any>Author.fetchOptions().credentials).to.eq("same-origin")
+      })
+    })
+
     context("clientApplication is set", () => {
       beforeEach(() => {
         Author.clientApplication = "test-app"


### PR DESCRIPTION
Currently you can't configure the fetch `credentials` header to change the way cookies are handled. This change would allow you to set a custom value.