### PR TITLE
Add custom fetcher config option

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -7,7 +7,8 @@ import {
   Request,
   RequestVerbs,
   JsonapiResponse,
-  ResponseError
+  ResponseError,
+  Fetcher
 } from "./request"
 import { WritePayload } from "./util/write-payload"
 import { flipEnumerable, getNonEnumerables } from "./util/enumerables"
@@ -171,6 +172,7 @@ export class SpraypaintBase {
   static credentials: "same-origin" | "omit" | "include" | undefined
   static clientApplication: string | null = null
   static patchAsPost: boolean = false
+  static fetcher: Fetcher = fetch
 
   static attributeList: Record<string, Attribute> = {}
   static linkList: Array<string> = []

--- a/src/model.ts
+++ b/src/model.ts
@@ -172,7 +172,6 @@ export class SpraypaintBase {
   static credentials: "same-origin" | "omit" | "include" | undefined
   static clientApplication: string | null = null
   static patchAsPost: boolean = false
-  static fetcher: Fetcher = fetch
 
   static attributeList: Record<string, Attribute> = {}
   static linkList: Array<string> = []
@@ -181,6 +180,8 @@ export class SpraypaintBase {
   static currentClass: typeof SpraypaintBase = SpraypaintBase
   static beforeFetch: BeforeFilter | undefined
   static afterFetch: AfterFilter | undefined
+  static fetcher: Fetcher = (input: RequestInfo, init?: RequestInit) =>
+    fetch(input, init)
 
   private static _typeRegistry: JsonapiTypeRegistry
   private static _IDMap: IDMap
@@ -689,10 +690,7 @@ export class SpraypaintBase {
       )
     }
 
-    return {
-      id: this.id,
-      type: this.klass.jsonapiType
-    }
+    return { id: this.id, type: this.klass.jsonapiType }
   }
 
   get errors(): ValidationErrors<this> {
@@ -952,9 +950,11 @@ export class SpraypaintBase {
   async destroy(): Promise<boolean> {
     const url = this.klass.url(this.id)
     const verb = "delete"
-    const request = new Request(this._middleware(), this.klass.logger, {
-      fetcher: this.klass.fetcher
-    })
+    const request = new Request(
+      this._middleware(),
+      this.klass.fetcher,
+      this.klass.logger
+    )
     let response: any
 
     try {
@@ -984,10 +984,14 @@ export class SpraypaintBase {
   ): Promise<boolean> {
     let url = this.klass.url()
     let verb: RequestVerbs = "post"
-    const request = new Request(this._middleware(), this.klass.logger, {
-      patchAsPost: this.klass.patchAsPost,
-      fetcher: this.klass.fetcher
-    })
+    const request = new Request(
+      this._middleware(),
+      this.klass.fetcher,
+      this.klass.logger,
+      {
+        patchAsPost: this.klass.patchAsPost
+      }
+    )
     const payload = new WritePayload(this, options.with)
     let response: any
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -148,7 +148,7 @@ export const applyModelConfig = <T extends typeof SpraypaintBase>(
 
   for (k in config) {
     if (config.hasOwnProperty(k)) {
-      ModelClass[k] = config[k]
+      ;(ModelClass[k] as any) = config[k]
     }
   }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -181,7 +181,7 @@ export class SpraypaintBase {
   static currentClass: typeof SpraypaintBase = SpraypaintBase
   static beforeFetch: BeforeFilter | undefined
   static afterFetch: AfterFilter | undefined
-  static fetcher: Fetcher = (input: RequestInfo, init?: RequestInit) =>
+  static fetcher: Fetcher = (input: string, init?: RequestInit) =>
     fetch(input, init)
 
   private static _typeRegistry: JsonapiTypeRegistry

--- a/src/model.ts
+++ b/src/model.ts
@@ -952,7 +952,9 @@ export class SpraypaintBase {
   async destroy(): Promise<boolean> {
     const url = this.klass.url(this.id)
     const verb = "delete"
-    const request = new Request(this._middleware(), this.klass.logger)
+    const request = new Request(this._middleware(), this.klass.logger, {
+      fetcher: this.klass.fetcher
+    })
     let response: any
 
     try {
@@ -983,7 +985,8 @@ export class SpraypaintBase {
     let url = this.klass.url()
     let verb: RequestVerbs = "post"
     const request = new Request(this._middleware(), this.klass.logger, {
-      patchAsPost: this.klass.patchAsPost
+      patchAsPost: this.klass.patchAsPost,
+      fetcher: this.klass.fetcher
     })
     const payload = new WritePayload(this, options.with)
     let response: any

--- a/src/model.ts
+++ b/src/model.ts
@@ -66,6 +66,7 @@ export interface ModelConfiguration {
   keyCase: KeyCase
   strictAttributes: boolean
   logger: ILogger
+  fetcher: Fetcher
 }
 export type ModelConfigurationOptions = Partial<ModelConfiguration>
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -9,9 +9,13 @@ export interface JsonapiResponse extends Response {
   jsonPayload: JsonapiResponseDoc
 }
 
-export interface RequestConfig {
+export type Fetcher = typeof fetch
+
+interface RequestConfig {
   patchAsPost: boolean
+  fetcher: Fetcher
 }
+type RequestConfigOptions = Partial<RequestConfig>
 
 export class Request {
   middleware: MiddlewareStack
@@ -21,11 +25,11 @@ export class Request {
   constructor(
     middleware: MiddlewareStack,
     logger: ILogger,
-    config?: RequestConfig
+    config?: RequestConfigOptions
   ) {
     this.middleware = middleware
     this.logger = logger
-    this.config = Object.assign({ patchAsPost: false }, config)
+    this.config = Object.assign({ patchAsPost: false, fetcher: fetch }, config)
   }
 
   get(url: string, options: RequestInit): Promise<any> {
@@ -104,7 +108,7 @@ export class Request {
     let response
 
     try {
-      response = await fetch(url, options)
+      response = await this.config.fetcher(url, options)
     } catch (e) {
       throw new ResponseError(null, e.message, e)
     }

--- a/src/request.ts
+++ b/src/request.ts
@@ -9,7 +9,7 @@ export interface JsonapiResponse extends Response {
   jsonPayload: JsonapiResponseDoc
 }
 
-export type Fetcher = typeof fetch
+export type Fetcher = (url: string, options: RequestInit) => Promise<any>
 
 interface RequestConfig {
   patchAsPost: boolean

--- a/src/request.ts
+++ b/src/request.ts
@@ -13,23 +13,24 @@ export type Fetcher = typeof fetch
 
 interface RequestConfig {
   patchAsPost: boolean
-  fetcher: Fetcher
 }
-type RequestConfigOptions = Partial<RequestConfig>
 
 export class Request {
   middleware: MiddlewareStack
+  fetcher: Fetcher
   config: RequestConfig
   private logger: ILogger
 
   constructor(
     middleware: MiddlewareStack,
+    fetcher: Fetcher,
     logger: ILogger,
-    config?: RequestConfigOptions
+    config?: RequestConfig
   ) {
     this.middleware = middleware
+    this.fetcher = fetcher
     this.logger = logger
-    this.config = Object.assign({ patchAsPost: false, fetcher: fetch }, config)
+    this.config = Object.assign({ patchAsPost: false }, config)
   }
 
   get(url: string, options: RequestInit): Promise<any> {
@@ -108,7 +109,7 @@ export class Request {
     let response
 
     try {
-      response = await this.config.fetcher(url, options)
+      response = await this.fetcher(url, options)
     } catch (e) {
       throw new ResponseError(null, e.message, e)
     }

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -336,9 +336,11 @@ export class Scope<T extends SpraypaintBase = SpraypaintBase> {
     if (qp) {
       url = `${url}?${qp}`
     }
-    const request = new Request(this.model.middlewareStack, this.model.logger, {
-      fetcher: this.model.fetcher
-    })
+    const request = new Request(
+      this.model.middlewareStack,
+      this.model.fetcher,
+      this.model.logger
+    )
     const response = await request.get(url, this.fetchOptions())
     refreshJWT(this.model, response)
     return response.jsonPayload

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -336,7 +336,9 @@ export class Scope<T extends SpraypaintBase = SpraypaintBase> {
     if (qp) {
       url = `${url}?${qp}`
     }
-    const request = new Request(this.model.middlewareStack, this.model.logger)
+    const request = new Request(this.model.middlewareStack, this.model.logger, {
+      fetcher: this.model.fetcher
+    })
     const response = await request.get(url, this.fetchOptions())
     refreshJWT(this.model, response)
     return response.jsonPayload

--- a/test/integration/custom-fetcher.test.ts
+++ b/test/integration/custom-fetcher.test.ts
@@ -1,0 +1,40 @@
+import { expect, sinon } from "../test-helper"
+import { Person } from "../fixtures"
+import fetchMock = require("fetch-mock")
+
+describe("Custom fetcher", () => {
+  const oldFetch = Person.fetcher
+  let spy: sinon.SinonSpy
+
+  beforeEach(() => {
+    spy = sinon.spy(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: {
+              id: "1",
+              type: "people",
+              attributes: {
+                firstName: "John"
+              }
+            }
+          })
+        )
+      )
+    )
+
+    Person.fetcher = spy
+  })
+
+  afterEach(() => {
+    Person.fetcher = oldFetch
+  })
+
+  it("calls the custom fetcher", async () => {
+    await Person.find(1)
+
+    expect(spy).to.have.been.calledOnce.and.to.have.been.calledWith(
+      "http://example.com/api/v1/people/1"
+    )
+  })
+})

--- a/test/integration/custom-fetcher.test.ts
+++ b/test/integration/custom-fetcher.test.ts
@@ -1,13 +1,17 @@
 import { expect, sinon } from "../test-helper"
-import { Person } from "../fixtures"
 import fetchMock = require("fetch-mock")
+import { Model, SpraypaintBase } from "../../src"
 
 describe("Custom fetcher", () => {
-  const oldFetch = Person.fetcher
-  let spy: sinon.SinonSpy
+  let spy1: sinon.SinonSpy
+  let spy2: sinon.SinonSpy
+
+  let ApplicationRecord: typeof SpraypaintBase
+  let Author: typeof SpraypaintBase
+  let Person: typeof SpraypaintBase
 
   beforeEach(() => {
-    spy = sinon.spy(() =>
+    const fetcher = (a: any, b: any) =>
       Promise.resolve(
         new Response(
           JSON.stringify({
@@ -21,20 +25,46 @@ describe("Custom fetcher", () => {
           })
         )
       )
-    )
 
-    Person.fetcher = spy
+    spy1 = sinon.spy(fetcher)
+    spy2 = sinon.spy(fetcher)
+
+    @Model({
+      baseUrl: "http://example.com",
+      apiNamespace: "/api/v1"
+    })
+    class Base extends SpraypaintBase {}
+    ApplicationRecord = Base
+
+    @Model({
+      jsonapiType: "authors",
+      fetcher: spy1
+    })
+    class A extends ApplicationRecord {}
+    Author = A
+
+    @Model({ jsonapiType: "people" })
+    class B extends ApplicationRecord {
+      static fetcher = spy2
+    }
+    Person = B
   })
 
-  afterEach(() => {
-    Person.fetcher = oldFetch
-  })
+  describe("uses custom fetchers", () => {
+    it("calls a custom fetcher set via config", async () => {
+      await Author.find(1)
 
-  it("calls the custom fetcher", async () => {
-    await Person.find(1)
+      expect(spy1).to.have.been.calledOnce.and.to.have.been.calledWith(
+        "http://example.com/api/v1/authors/1"
+      )
+    })
 
-    expect(spy).to.have.been.calledOnce.and.to.have.been.calledWith(
-      "http://example.com/api/v1/people/1"
-    )
+    it("calls a custom fetcher set via static props", async () => {
+      await Person.find(1)
+
+      expect(spy2).to.have.been.calledOnce.and.to.have.been.calledWith(
+        "http://example.com/api/v1/people/1"
+      )
+    })
   })
 })


### PR DESCRIPTION
Adds an option to use your own `fetch` function:


```typescript
import { Model, SpraypaintBase } from 'spraypaint'
import ky from 'ky'

const apiClient = ky.extend({})

@Model()
class ApplicationRecord extends SpraypaintBase {
  static fetcher = apiClient
}
```