### PR TITLE
Finder methods return "Persisted" type of a record

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { SpraypaintBase } from "./model"
+export { SpraypaintBase, PersistedSpraypaintRecord } from "./model"
 
 export { Attribute, attr } from "./attribute"
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -1099,6 +1099,11 @@ export class SpraypaintBase {
   }
 }
 
+export type PersistedSpraypaintRecord<
+  Record extends SpraypaintBase
+> = Record & {
+  id: string
+}
 ;(<any>SpraypaintBase.prototype).klass = SpraypaintBase
 SpraypaintBase.initializeCredentialStorage()
 

--- a/src/proxies/collection-proxy.ts
+++ b/src/proxies/collection-proxy.ts
@@ -1,13 +1,16 @@
-import { SpraypaintBase } from "../model"
+import { SpraypaintBase, PersistedSpraypaintRecord } from "../model"
 import { IResultProxy } from "./index"
 import { JsonapiResponseDoc } from "../jsonapi-spec"
 
 export class CollectionProxy<T extends SpraypaintBase>
   implements IResultProxy<T> {
   private _raw_json: JsonapiResponseDoc
-  private _collection: T[]
+  private _collection: PersistedSpraypaintRecord<T>[]
 
-  constructor(collection: T[], raw_json: JsonapiResponseDoc = { data: [] }) {
+  constructor(
+    collection: PersistedSpraypaintRecord<T>[],
+    raw_json: JsonapiResponseDoc = { data: [] }
+  ) {
     this._collection = collection
     this._raw_json = raw_json
   }
@@ -16,7 +19,7 @@ export class CollectionProxy<T extends SpraypaintBase>
     return this._raw_json
   }
 
-  get data(): T[] {
+  get data(): PersistedSpraypaintRecord<T>[] {
     return this._collection
   }
 

--- a/src/proxies/index.ts
+++ b/src/proxies/index.ts
@@ -1,10 +1,11 @@
 export { CollectionProxy } from "./collection-proxy"
 export { RecordProxy } from "./record-proxy"
 export { NullProxy } from "./null-proxy"
+import { PersistedSpraypaintRecord, SpraypaintBase } from "../model"
 import { JsonapiResponseDoc } from "../jsonapi-spec"
 
-export interface IResultProxy<T> {
-  data: T | T[] | null
+export interface IResultProxy<T extends SpraypaintBase> {
+  data: PersistedSpraypaintRecord<T> | PersistedSpraypaintRecord<T>[] | null
   meta: Record<string, any>
   raw: JsonapiResponseDoc
 }

--- a/src/proxies/record-proxy.ts
+++ b/src/proxies/record-proxy.ts
@@ -1,12 +1,16 @@
 import { SpraypaintBase } from "../model"
 import { IResultProxy } from "./index"
 import { JsonapiResponseDoc } from "../jsonapi-spec"
+import { PersistedSpraypaintRecord } from "../model"
 
 export class RecordProxy<T extends SpraypaintBase> implements IResultProxy<T> {
   private _raw_json: JsonapiResponseDoc
-  private _record: T
+  private _record: PersistedSpraypaintRecord<T>
 
-  constructor(record: T, raw_json: JsonapiResponseDoc) {
+  constructor(
+    record: PersistedSpraypaintRecord<T>,
+    raw_json: JsonapiResponseDoc
+  ) {
     this._record = record
     this._raw_json = raw_json
   }
@@ -15,7 +19,7 @@ export class RecordProxy<T extends SpraypaintBase> implements IResultProxy<T> {
     return this._raw_json
   }
 
-  get data(): T {
+  get data(): PersistedSpraypaintRecord<T> {
     return this._record
   }
 

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -1,4 +1,4 @@
-import { SpraypaintBase } from "./model"
+import { SpraypaintBase, PersistedSpraypaintRecord } from "./model"
 import parameterize from "./util/parameterize"
 import {
   IncludeDirective,
@@ -347,7 +347,7 @@ export class Scope<T extends SpraypaintBase = SpraypaintBase> {
     jsonResult: JsonapiCollectionDoc
   ): RecordProxy<T> | NullProxy
   private _buildRecordResult(jsonResult: JsonapiSuccessDoc) {
-    let record: T
+    let record: PersistedSpraypaintRecord<T>
 
     let rawRecord: JsonapiResource
     if (jsonResult.data instanceof Array) {
@@ -365,7 +365,7 @@ export class Scope<T extends SpraypaintBase = SpraypaintBase> {
   }
 
   private _buildCollectionResult(jsonResult: JsonapiCollectionDoc) {
-    const recordArray: T[] = []
+    const recordArray: PersistedSpraypaintRecord<T>[] = []
 
     jsonResult.data.forEach(record => {
       recordArray.push(this.model.fromJsonapi(record, jsonResult))


### PR DESCRIPTION
This adds a new `PersistedSpraypaintRecord` type which extends any
record type, definining the id as `string` instead of the initial
`string | undefined`. This will allow any record retrieved from
finders to be correctly typed with a defined id. This should avoid the
need for a bunch of boilerplate type guards when dealing with records
which are always coming from from finders. You can also use this to
manually cast a record after you save it:

```typescript
function createPerson(attrs): PersistedSpraypaintRecord<Person>
  let person = new Person(attrs)

  let success = await person.save()

  if (success) {
    person = person as PersistedSpraypaintRecord<Person>
  } else {
    // handle error
  }
}
```