### PR TITLE
Disable localStorage use when jwtStorage set to false

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -194,7 +194,7 @@ export class SpraypaintBase {
   static set jwtStorage(val: string | false) {
     if (val !== this._jwtStorage) {
       this._jwtStorage = val
-      this.credentialStorageBackend = this._credentialStorageBackend
+      this.initializeCredentialStorage()
     }
   }
 

--- a/test/unit/model.test.ts
+++ b/test/unit/model.test.ts
@@ -107,6 +107,13 @@ describe("Model", () => {
                 localStorageStub
               )
             })
+
+            it("is disabled when jwtStorage is false", () => {
+              SpraypaintBase.jwtStorage = false
+              expect(SpraypaintBase.credentialStorageBackend).to.be.instanceOf(
+                InMemoryStorageBackend
+              )
+            })
           })
 
           context("localStorage API is not defined", () => {


### PR DESCRIPTION
When setting `jwtStorage` to `false` on your record base class, the internal credential storage backend was not properly being updated.

A minimal failing example of this that you can just run in Node is:

```js
// Mock this since we're in Node
global.localStorage = {
  setItem: () => { console.log("Never should have come here!") }
}

const Spraypaint = require("spraypaint")
const ApplicationRecord = Spraypaint.SpraypaintBase.extend({})

ApplicationRecord.jwtStorage = false
ApplicationRecord.setJWT("token")

```

Reinitializing credential storage properly checks for this and disables it as expected.