### PR TITLE
Handle request retry or re-routing in middleware.afterFilters 

### DIFF
--- a/src/middleware-stack.ts
+++ b/src/middleware-stack.ts
@@ -1,5 +1,9 @@
 export type BeforeFilter = (requestUrl: string, options: RequestInit) => void
-export type AfterFilter = (response: Response, json: JSON) => void
+export type AfterFilter = (
+  response: Response,
+  json: JSON,
+  requestOptions: RequestInit
+) => void
 
 async function asyncForEach(array: Array<Function>, callback: Function) {
   for (let index = 0; index < array.length; index += 1) {
@@ -10,10 +14,12 @@ async function asyncForEach(array: Array<Function>, callback: Function) {
 export class MiddlewareStack {
   private _beforeFilters: BeforeFilter[] = []
   private _afterFilters: AfterFilter[] = []
+  public newResponse: Response | null = null
 
   constructor(before: BeforeFilter[] = [], after: AfterFilter[] = []) {
     this._beforeFilters = before
     this._afterFilters = after
+    this.newResponse = null
   }
 
   get beforeFilters() {
@@ -30,9 +36,13 @@ export class MiddlewareStack {
     })
   }
 
-  async afterFetch(response: Response, json: JSON) {
+  async afterFetch(
+    response: Response,
+    json: JSON,
+    requestOptions: RequestInit
+  ) {
     await asyncForEach(this._afterFilters, async (filter: Function) => {
-      await filter(response, json)
+      await filter(response, json, requestOptions)
     })
   }
 }


### PR DESCRIPTION
Hi guys,

**Problem:** I recently wanted to handle refresh token. My goal was to catch 401 response, get a new token, then retry the request that failed. However, there is no way to modify the response in the middleware.afterFilters function (to return the successfully response instead of the failed one).

**Solution:** I added a variable to MiddlewareStack Class named "newResponse: Response | null". If this variable is set in middleware.afterFilters function, it will be used as the new response instead of the original response passed to the middleware. I also added the requestOptions, so we can have all the information about the request that failed, to retry it for example. This way, we can handle retry request or re-routing in middleware.afterFilters.

Example - Catch 401 error, get new token then retry the request that failed: 

```js
middleware.afterFilters.push(async(response: Response, json: JSON, requestOptions: RequestInit) => {
  if (response.status === 401) {
    await UserModule.RefreshToken()

    requestOptions.headers.Authorization = `Bearer ${getToken()}`
    const result = await fetch(response.url, requestOptions)

    middleware.newResponse = result
  }
}
```

Don't hesitate to tell me if you think about better variable naming or better code implementation.