### PR TITLE
validation errors appear when relationship has nested records

### DIFF
--- a/src/util/validation-error-builder.ts
+++ b/src/util/validation-error-builder.ts
@@ -82,7 +82,8 @@ export class ValidationErrorBuilder<T extends SpraypaintBase> {
 
     if (meta.relationship) {
       this._processRelationship(relatedObject, meta.relationship, err)
-    } else {
+    }
+    else if (relatedObject) {
       const relatedAccumulator: ValidationErrors<R> = {}
       this._processResource(relatedAccumulator, meta, err)
 

--- a/src/util/validation-error-builder.ts
+++ b/src/util/validation-error-builder.ts
@@ -82,7 +82,7 @@ export class ValidationErrorBuilder<T extends SpraypaintBase> {
 
     if (meta.relationship) {
       this._processRelationship(relatedObject, meta.relationship, err)
-    }
+    } 
     else if (relatedObject) {
       const relatedAccumulator: ValidationErrors<R> = {}
       this._processResource(relatedAccumulator, meta, err)


### PR DESCRIPTION
**Problem**
We ran across an issue with spraypaint in which we have an object that is deeply nested and has many associations with < _grand children_ > with below hierarchy ; 

`Parent < has many > children and <childern> has many < grand children> `


Spraypaint expects relationship errors to be nested but GraphitiErrors does not provide much information for the < grandchildren > records and aborts on associating errors with result objects and results in errors on clientside in the console of the browser. 

**Solution:** 

When spraypaint transverse the path structure of the errors, it doesn't get the relatedRecord object for deeply nested grandchildren and return the exception which can be avoided to check if we have relatedRecord before executing the error block.  With this new patch, errors for missing grandchildren will be silently dropped which is still better than crashing the application. 


**Motivation**:

Crashing the client application gives a bad impact, rather ignore for smooth operation to return. 