### PR TITLE
Permanent fix for React Native / IE encoding bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spraypaint
 
-A fork of the JS Client for [Graphiti](https://graphiti-api.github.io/graphiti) similar to ActiveRecord, made compatible with React-Native.
+A fork of the JS Client for [Graphiti](https://graphiti-api.github.io/graphiti), made compatible with React-Native.
 This repository will be deleted if the compatibility-focused changes are merged into the main project. 
 
 Written in [Typescript](https://www.typescriptlang.org) but works in plain old ES5 as well. This library is isomorphic - use it from the browser, or from the server with NodeJS.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Spraypaint
 
-JS Client for [Graphiti](https://graphiti-api.github.io/graphiti) similar to ActiveRecord.
+A fork of the JS Client for [Graphiti](https://graphiti-api.github.io/graphiti) similar to ActiveRecord, made compatible with React-Native.
+This repository will be deleted if the compatibility-focused changes are merged into the main project. 
 
 Written in [Typescript](https://www.typescriptlang.org) but works in plain old ES5 as well. This library is isomorphic - use it from the browser, or from the server with NodeJS.
 

--- a/src/util/parameterize.ts
+++ b/src/util/parameterize.ts
@@ -36,7 +36,9 @@ const parameterize = (obj: any, prefix?: string): string => {
 
 // IE does not encode by default like other browsers
 const maybeEncode = (value: string): string => {
-  const isBrowser = typeof window !== "undefined"
+  var isBrowser =
+    typeof window !== "undefined" &&
+    typeof window.navigator.userAgent !== "undefined"
   const isIE = isBrowser && window.navigator.userAgent.match(/(MSIE|Trident)/)
   const isEncoded = typeof value === "string" && value.indexOf("%") !== -1
   const shouldEncode = isBrowser && isIE && !isEncoded


### PR DESCRIPTION
This is a follow-up PR to #84 which was reverted in PR #99 after @richmolj  found a broken test. I'd like to propose this PR as a possible permanent fix. React Native uses a window and window.navigator, but does not have a userAgent property. The existence of the window.navigator.userAgent property is a more precise check to make than the document. 

All tests are passing on my end. It fixed our app in dev and deployed environments.
