### PR TITLE
Adds constructor assignment for collections

### DIFF
--- a/src/associations.ts
+++ b/src/associations.ts
@@ -114,7 +114,12 @@ export class HasMany<T extends SpraypaintBase> extends Attribute<T[]>
     if (val && !val.hasOwnProperty("isRelationship")) {
       if (!(val instanceof SpraypaintBase) && !Array.isArray(val)) {
         val = new this.klass(val)
+      } else if (Array.isArray(val)) {
+        val = val.map(v =>
+          v instanceof SpraypaintBase ? v : new this.klass(v)
+        )
       }
+
       context.relationships[this.name] = val
     } else if (val === null || val === undefined) {
       context.relationships[this.name] = val

--- a/test/unit/model-relationships.test.ts
+++ b/test/unit/model-relationships.test.ts
@@ -1,5 +1,5 @@
 import { expect, sinon } from "../test-helper"
-import { Author, Genre } from "../fixtures"
+import { Author, Book, Genre } from "../fixtures"
 
 describe("Model relationships", () => {
   it("supports direct assignment of models", () => {
@@ -27,6 +27,15 @@ describe("Model relationships", () => {
     const author = new Author({ genre: { name: "Horror" } })
     expect(author.genre).to.be.instanceof(Genre)
     expect(author.genre.name).to.eq("Horror")
+  })
+
+  it("supports constructor assignment of collections", () => {
+    const author = new Author({
+      books: [{ title: "The Shining" }, { title: "The Darkening" }]
+    })
+    expect(author.books.length).to.eq(2)
+    expect(author.books[0]).to.be.instanceof(Book)
+    expect(author.books[1]).to.be.instanceof(Book)
   })
 
   it("defaults hasMany to empty collection", () => {


### PR DESCRIPTION
This PR extends the existing feature allowing the creation of associations with bare objects, e.g:
```javascript
 const author = new Author({ genre: { name: "Horror" } })
```
to allow collections to be created:
```javascript
const author = new Author({
      books: [{ title: "The Shining" }, { title: "The Darkening" }]
})
```

Currently the above snippet would result in books being an empty array, where-as now it will correctly create the two `Book` objects.